### PR TITLE
feat: add welcome screen with visual template catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Plugin CSS files moved to `static/css/plugins/` mirroring the `static/js/plugins/` structure
 * JSDoc-style `/** */` docstrings on jQuery plugin definitions with actions and events
 * Profile selector jQuery plugin (`plugins/profileselector.js`) for profile and variant dropdown management
+* Welcome screen at `/welcome` with a visual template catalog of the available profiles (image, name, dimensions)
+* Welcome jQuery plugin (`plugins/welcome.js`, `css/welcome.css`) with `load` and `value` actions
+* Forwarding of `profile` and `variant` query parameters from the gateway POST to the editor for template pre-selection
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Font deselection handler now clears stored font state and updates URL
 * Backspace at caret start position no longer corrupts text state
 * Server-side validation for `preview.zoom` field in profile schema
+* `lang` attribute on Portuguese views (`welcome-pt_pt.ejs`, `gateway-pt_pt.ejs`, `report-pt_pt.ejs`) corrected from `en` to `pt`
+* Welcome catalog `background-image` URLs now pass profile filenames through `encodeURI` to guard against malformed CSS
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Welcome screen at `/welcome` with a visual template catalog of the available profiles (image, name, dimensions)
 * Welcome jQuery plugin (`plugins/welcome.js`, `css/welcome.css`) with `load` and `value` actions
 * Forwarding of `profile` and `variant` query parameters from the gateway POST to the editor for template pre-selection
+* Session-tracked entry point so the back arrow in the viewport, signature, and report views returns to the welcome screen or classic gateway depending on where the user came from
+* Restoration of the previously selected template card on the welcome catalog when navigating back from the editor
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Forwarding of `profile` and `variant` query parameters from the gateway POST to the editor for template pre-selection
 * Session-tracked entry point so the back arrow in the viewport, signature, and report views returns to the welcome screen or classic gateway depending on where the user came from
 * Restoration of the previously selected template card on the welcome catalog when navigating back from the editor
+* Portuguese (`pt_pt`) translation of the welcome screen mirroring the existing `welcome.ejs` layout
 
 ### Fixed
 

--- a/app.js
+++ b/app.js
@@ -75,6 +75,11 @@ app.post("/gateway", (req, res, next) => {
     req.session.config = Object.assign({}, req.body);
     const elements = req.session.config.elements;
 
+    // remembers the entry point that submitted the gateway form
+    // so that downstream views can render a back button that
+    // returns to the same place the user came from
+    req.session.entry = req.body.entry === "welcome" ? "welcome" : "gateway";
+
     // builds the optional profile/variant query string so that
     // a template selection made on the welcome screen is forwarded
     // to the editor for automatic pre-selection
@@ -120,7 +125,8 @@ app.get("/signature", (req, res, next) => {
     req.session.theme = theme;
     res.render("signature", {
         fullscreen: fullscreen,
-        theme: theme
+        theme: theme,
+        back: req.session.entry === "welcome" ? "/welcome" : "/"
     });
 });
 
@@ -137,7 +143,8 @@ app.get("/viewport", (req, res, next) => {
         masterb64: masterb64,
         options: master[req.session.config.technology] || {},
         config: req.session.config || {},
-        text: lib.deserializeText(req.session.config.text) || null
+        text: lib.deserializeText(req.session.config.text) || null,
+        back: req.session.entry === "welcome" ? "/welcome" : "/"
     });
 });
 
@@ -157,7 +164,8 @@ app.get("/report", (req, res, next) => {
         config: req.session.config || {},
         text: lib.deserializeText(req.session.config.text) || null,
         font: lib.fontText(req.session.config.text) || null,
-        localize: (v, f) => lib.localize(v, locale || undefined, f)
+        localize: (v, f) => lib.localize(v, locale || undefined, f),
+        back: req.session.entry === "welcome" ? "/welcome" : "/"
     });
 });
 

--- a/app.js
+++ b/app.js
@@ -109,7 +109,7 @@ app.get("/welcome", (req, res, next) => {
     const locale = req.query.locale || req.session.locale || "";
     req.session.theme = theme;
     req.session.locale = locale;
-    res.render("welcome", {
+    res.render("welcome" + (locale ? `-${locale}` : ""), {
         fullscreen: fullscreen,
         theme: theme,
         master: master,

--- a/app.js
+++ b/app.js
@@ -74,19 +74,44 @@ app.get(["/", "/gateway"], (req, res, next) => {
 app.post("/gateway", (req, res, next) => {
     req.session.config = Object.assign({}, req.body);
     const elements = req.session.config.elements;
+
+    // builds the optional profile/variant query string so that
+    // a template selection made on the welcome screen is forwarded
+    // to the editor for automatic pre-selection
+    const params = new URLSearchParams();
+    if (req.session.config.profile) params.set("profile", req.session.config.profile);
+    if (req.session.config.variant) params.set("variant", req.session.config.variant);
+    const query = params.toString() ? "?" + params.toString() : "";
+
     switch (elements) {
         case "text":
-            res.redirect(302, "/viewport");
+            res.redirect(302, "/viewport" + query);
             break;
         case "digital_printing":
         case "graphic_element":
-            res.redirect(302, "/report");
+            res.redirect(302, "/report" + query);
             break;
         case "calligraphy":
         default:
-            res.redirect(302, "/signature");
+            res.redirect(302, "/signature" + query);
             break;
     }
+});
+
+app.get("/welcome", (req, res, next) => {
+    const fullscreen = req.query.fullscreen === "1";
+    const theme = req.query.theme || req.session.theme || "";
+    const locale = req.query.locale || req.session.locale || "";
+    req.session.theme = theme;
+    req.session.locale = locale;
+    res.render("welcome", {
+        fullscreen: fullscreen,
+        theme: theme,
+        master: master,
+        masterb64: masterb64,
+        config: req.session.config || {},
+        info: info || {}
+    });
 });
 
 app.get("/signature", (req, res, next) => {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -11,6 +11,7 @@ const CSS_FILES = [
     "css/signature.css",
     "css/text.css",
     "css/viewport.css",
+    "css/welcome.css",
     "css/plugins/collapsible.css",
     "css/plugins/console.css",
     "css/plugins/inspiration.css",
@@ -31,6 +32,7 @@ const JS_FILES = [
     "js/plugins/texteditor.js",
     "js/plugins/toast.js",
     "js/plugins/viewportpreview.js",
+    "js/plugins/welcome.js",
     "js/main.js"
 ];
 

--- a/static/css/bundle.css
+++ b/static/css/bundle.css
@@ -1435,7 +1435,15 @@ body.ldj .line {
 }
 
 .welcome .welcome-action-bar > .welcome-actions > .button {
+    box-sizing: border-box;
+    -o-box-sizing: border-box;
+    -ms-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    -khtml-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
     min-width: 120px;
+    text-align: center;
+    vertical-align: middle;
 }
 
 .welcome .welcome-action-bar > .welcome-actions > .button.button-ghost {

--- a/static/css/bundle.css
+++ b/static/css/bundle.css
@@ -1121,6 +1121,209 @@ body.ldj .line {
     width: 0px;
 }
 
+.welcome {
+    align-items: center;
+    background-color: #f4f7fa;
+    display: flex;
+    min-height: 100%;
+    padding: 48px 0px 64px 0px;
+}
+
+.welcome > .form.form-welcome {
+    max-width: 960px;
+    min-width: 720px;
+}
+
+.welcome > .form > .welcome-headline {
+    margin: 8px 0px 24px 0px;
+    text-align: center;
+}
+
+.welcome > .form > .welcome-headline > .welcome-title {
+    color: #2d2d2d;
+    font-size: 28px;
+    font-weight: 300;
+    letter-spacing: 0.5px;
+    margin: 0px 0px 8px 0px;
+}
+
+.welcome > .form > .welcome-headline > .welcome-subtitle {
+    color: #6b7280;
+    font-size: 14px;
+    font-weight: 400;
+    letter-spacing: 0.25px;
+    margin: 0px 0px 0px 0px;
+}
+
+.welcome > .form > .catalog-container {
+    margin: 0px 0px 24px 0px;
+}
+
+.welcome > .form > .catalog-container > .catalog {
+    -ms-grid-columns: 1fr 12px 1fr 12px 1fr;
+    display: -ms-grid;
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(3, 1fr);
+}
+
+.welcome > .form > .catalog-container > .catalog > .catalog-card {
+    background-color: #ffffff;
+    border: 2px solid #ececec;
+    border-radius: 6px 6px 6px 6px;
+    -o-border-radius: 6px 6px 6px 6px;
+    -ms-border-radius: 6px 6px 6px 6px;
+    -moz-border-radius: 6px 6px 6px 6px;
+    -khtml-border-radius: 6px 6px 6px 6px;
+    -webkit-border-radius: 6px 6px 6px 6px;
+    box-sizing: border-box;
+    -o-box-sizing: border-box;
+    -ms-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    -khtml-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    cursor: pointer;
+    overflow: hidden;
+    padding: 0px 0px 0px 0px;
+    text-align: center;
+    transition: border-color 0.2s ease, transform 0.2s ease;
+    -o-transition: border-color 0.2s ease, transform 0.2s ease;
+    -ms-transition: border-color 0.2s ease, transform 0.2s ease;
+    -moz-transition: border-color 0.2s ease, transform 0.2s ease;
+    -khtml-transition: border-color 0.2s ease, transform 0.2s ease;
+    -webkit-transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.welcome > .form > .catalog-container > .catalog > .catalog-card:hover {
+    border-color: #d0d0d0;
+    transform: translateY(-2px);
+    -o-transform: translateY(-2px);
+    -ms-transform: translateY(-2px);
+    -moz-transform: translateY(-2px);
+    -khtml-transform: translateY(-2px);
+    -webkit-transform: translateY(-2px);
+}
+
+.welcome > .form > .catalog-container > .catalog > .catalog-card.selected {
+    border-color: #2d2d2d;
+}
+
+.welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-image {
+    background-color: #f4f7fa;
+    background-position: center center;
+    background-repeat: no-repeat;
+    background-size: contain;
+    height: 160px;
+    width: 100%;
+}
+
+.welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body {
+    padding: 12px 12px 12px 12px;
+}
+
+.welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-name {
+    color: #2d2d2d;
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 0.25px;
+    margin: 0px 0px 4px 0px;
+}
+
+.welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-meta {
+    color: #6b7280;
+    font-size: 11px;
+    font-weight: 400;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+}
+
+.welcome > .form > .catalog-container > .catalog > .catalog-card.empty {
+    color: #6b7280;
+    cursor: default;
+    font-size: 13px;
+    font-weight: 400;
+    grid-column: 1 / -1;
+    padding: 32px 0px 32px 0px;
+    text-align: center;
+}
+
+.welcome > .form > .catalog-container > .catalog > .catalog-card.empty:hover {
+    border-color: #ececec;
+    transform: none;
+    -o-transform: none;
+    -ms-transform: none;
+    -moz-transform: none;
+    -khtml-transform: none;
+    -webkit-transform: none;
+}
+
+.welcome > .form > .buttons-container > .button-classic {
+    margin-left: 14px;
+}
+
+.welcome > .form > .buttons-container > .button[disabled] {
+    cursor: not-allowed;
+    opacity: 0.5;
+    -o-opacity: 0.5;
+    -ms-opacity: 0.5;
+    -moz-opacity: 0.5;
+    -khtml-opacity: 0.5;
+    -webkit-opacity: 0.5;
+}
+
+.welcome > .footer {
+    bottom: 0px;
+    font-size: 11px;
+    font-weight: 600;
+    height: 24px;
+    letter-spacing: 0.25px;
+    position: absolute;
+    text-align: center;
+    text-transform: uppercase;
+    width: 100%;
+}
+
+body.ldj .welcome {
+    background-color: #faf8fc;
+}
+
+body.ldj .welcome > .form > .welcome-headline > .welcome-title {
+    color: #1f1430;
+    font-weight: 200;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+}
+
+body.ldj .welcome > .form > .welcome-headline > .welcome-subtitle {
+    color: #6b5a8a;
+    font-style: italic;
+    letter-spacing: 0.5px;
+}
+
+body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card {
+    border-color: #ece4f5;
+}
+
+body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card:hover {
+    border-color: #c9b6e5;
+}
+
+body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card.selected {
+    border-color: #9678d3;
+}
+
+body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-image {
+    background-color: #f5f0fa;
+}
+
+body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-name {
+    color: #1f1430;
+}
+
+body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-meta {
+    color: #6b5a8a;
+}
+
 .collapsible > .collapsible-title {
     cursor: pointer;
     margin-bottom: 12px;

--- a/static/css/bundle.css
+++ b/static/css/bundle.css
@@ -1122,60 +1122,122 @@ body.ldj .line {
 }
 
 .welcome {
-    align-items: center;
-    background-color: #f4f7fa;
+    background-color: #f8f9fb;
+    box-sizing: border-box;
+    -o-box-sizing: border-box;
+    -ms-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    -khtml-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
     display: flex;
-    min-height: 100%;
-    padding: 48px 0px 64px 0px;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+    width: 100%;
 }
 
 .welcome > .form.form-welcome {
-    max-width: 960px;
-    min-width: 720px;
+    background-color: transparent;
+    border-radius: 0px;
+    -o-border-radius: 0px;
+    -ms-border-radius: 0px;
+    -moz-border-radius: 0px;
+    -khtml-border-radius: 0px;
+    -webkit-border-radius: 0px;
+    box-shadow: none;
+    -o-box-shadow: none;
+    -ms-box-shadow: none;
+    -moz-box-shadow: none;
+    -khtml-box-shadow: none;
+    -webkit-box-shadow: none;
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    margin: 0px 0px 0px 0px;
+    max-width: none;
+    min-height: 0;
+    min-width: 0;
+    padding: 0px 0px 0px 0px;
+    width: 100%;
 }
 
-.welcome > .form > .welcome-headline {
-    margin: 8px 0px 24px 0px;
+.welcome .welcome-hero {
+    flex: 0 0 auto;
+    padding: 32px 48px 20px 48px;
     text-align: center;
 }
 
-.welcome > .form > .welcome-headline > .welcome-title {
+.welcome .welcome-hero > .welcome-hero-mark {
+    margin-bottom: 12px;
+}
+
+.welcome .welcome-hero > .welcome-hero-mark > .logo {
+    height: 28px;
+    width: auto;
+}
+
+.welcome .welcome-hero > .welcome-hero-mark > span.logo {
     color: #2d2d2d;
-    font-size: 28px;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+}
+
+.welcome .welcome-hero > .welcome-hero-eyebrow {
+    color: #9aa0ad;
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 3px;
+    margin-bottom: 8px;
+    text-transform: uppercase;
+}
+
+.welcome .welcome-hero > .welcome-hero-title {
+    color: #1f2330;
+    font-size: 24px;
     font-weight: 300;
     letter-spacing: 0.5px;
-    margin: 0px 0px 8px 0px;
+    margin: 0px 0px 16px 0px;
 }
 
-.welcome > .form > .welcome-headline > .welcome-subtitle {
-    color: #6b7280;
-    font-size: 14px;
-    font-weight: 400;
-    letter-spacing: 0.25px;
-    margin: 0px 0px 0px 0px;
+.welcome .welcome-hero > .welcome-hero-divider {
+    background-color: #d8dde6;
+    height: 1px;
+    margin: 0px auto 0px auto;
+    width: 48px;
 }
 
-.welcome > .form > .catalog-container {
-    margin: 0px 0px 24px 0px;
+.welcome .welcome-catalog {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: 8px 48px 8px 48px;
 }
 
-.welcome > .form > .catalog-container > .catalog {
-    -ms-grid-columns: 1fr 12px 1fr 12px 1fr;
+.welcome .welcome-catalog > .catalog-container {
+    margin: 0px auto 0px auto;
+    max-width: 1080px;
+}
+
+.welcome .welcome-catalog > .catalog-container > .catalog {
+    -ms-grid-columns: 1fr 12px 1fr 12px 1fr 12px 1fr;
     display: -ms-grid;
     display: grid;
     gap: 12px;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
 }
 
-.welcome > .form > .catalog-container > .catalog > .catalog-card {
+.welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card {
     background-color: #ffffff;
-    border: 2px solid #ececec;
-    border-radius: 6px 6px 6px 6px;
-    -o-border-radius: 6px 6px 6px 6px;
-    -ms-border-radius: 6px 6px 6px 6px;
-    -moz-border-radius: 6px 6px 6px 6px;
-    -khtml-border-radius: 6px 6px 6px 6px;
-    -webkit-border-radius: 6px 6px 6px 6px;
+    border: 1px solid #e6e8ee;
+    border-radius: 4px 4px 4px 4px;
+    -o-border-radius: 4px 4px 4px 4px;
+    -ms-border-radius: 4px 4px 4px 4px;
+    -moz-border-radius: 4px 4px 4px 4px;
+    -khtml-border-radius: 4px 4px 4px 4px;
+    -webkit-border-radius: 4px 4px 4px 4px;
     box-sizing: border-box;
     -o-box-sizing: border-box;
     -ms-box-sizing: border-box;
@@ -1186,16 +1248,22 @@ body.ldj .line {
     overflow: hidden;
     padding: 0px 0px 0px 0px;
     text-align: center;
-    transition: border-color 0.2s ease, transform 0.2s ease;
-    -o-transition: border-color 0.2s ease, transform 0.2s ease;
-    -ms-transition: border-color 0.2s ease, transform 0.2s ease;
-    -moz-transition: border-color 0.2s ease, transform 0.2s ease;
-    -khtml-transition: border-color 0.2s ease, transform 0.2s ease;
-    -webkit-transition: border-color 0.2s ease, transform 0.2s ease;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    -o-transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    -ms-transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    -moz-transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    -khtml-transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    -webkit-transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
-.welcome > .form > .catalog-container > .catalog > .catalog-card:hover {
-    border-color: #d0d0d0;
+.welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card:hover {
+    border-color: #cfd4de;
+    box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.06);
+    -o-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.06);
+    -ms-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.06);
+    -moz-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.06);
+    -khtml-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.06);
+    -webkit-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.06);
     transform: translateY(-2px);
     -o-transform: translateY(-2px);
     -ms-transform: translateY(-2px);
@@ -1204,51 +1272,66 @@ body.ldj .line {
     -webkit-transform: translateY(-2px);
 }
 
-.welcome > .form > .catalog-container > .catalog > .catalog-card.selected {
-    border-color: #2d2d2d;
+.welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card.selected {
+    border-color: #1f2330;
+    box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.1);
+    -o-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.1);
+    -ms-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.1);
+    -moz-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.1);
+    -khtml-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.1);
+    -webkit-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.1);
 }
 
-.welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-image {
-    background-color: #f4f7fa;
+.welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card > .catalog-card-image {
+    background-color: #f4f5f8;
     background-position: center center;
     background-repeat: no-repeat;
     background-size: contain;
-    height: 160px;
+    height: 110px;
     width: 100%;
 }
 
-.welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body {
-    padding: 12px 12px 12px 12px;
+.welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card > .catalog-card-body {
+    padding: 8px 8px 10px 8px;
 }
 
-.welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-name {
-    color: #2d2d2d;
-    font-size: 14px;
+.welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-name {
+    color: #1f2330;
+    font-size: 12px;
     font-weight: 600;
     letter-spacing: 0.25px;
-    margin: 0px 0px 4px 0px;
+    margin: 0px 0px 2px 0px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-meta {
-    color: #6b7280;
-    font-size: 11px;
-    font-weight: 400;
-    letter-spacing: 0.5px;
+.welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-meta {
+    color: #9aa0ad;
+    font-size: 9px;
+    font-weight: 500;
+    letter-spacing: 0.75px;
     text-transform: uppercase;
 }
 
-.welcome > .form > .catalog-container > .catalog > .catalog-card.empty {
-    color: #6b7280;
+.welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card.empty {
+    color: #9aa0ad;
     cursor: default;
-    font-size: 13px;
+    font-size: 12px;
     font-weight: 400;
     grid-column: 1 / -1;
     padding: 32px 0px 32px 0px;
     text-align: center;
 }
 
-.welcome > .form > .catalog-container > .catalog > .catalog-card.empty:hover {
-    border-color: #ececec;
+.welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card.empty:hover {
+    border-color: #e6e8ee;
+    box-shadow: none;
+    -o-box-shadow: none;
+    -ms-box-shadow: none;
+    -moz-box-shadow: none;
+    -khtml-box-shadow: none;
+    -webkit-box-shadow: none;
     transform: none;
     -o-transform: none;
     -ms-transform: none;
@@ -1257,71 +1340,225 @@ body.ldj .line {
     -webkit-transform: none;
 }
 
-.welcome > .form > .buttons-container > .button-classic {
-    margin-left: 14px;
+.welcome .welcome-action-bar {
+    background-color: #ffffff;
+    border-top: 1px solid #e6e8ee;
+    box-sizing: border-box;
+    -o-box-sizing: border-box;
+    -ms-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    -khtml-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    display: flex;
+    flex: 0 0 auto;
+    flex-wrap: wrap;
+    gap: 16px;
+    padding: 16px 48px 16px 48px;
 }
 
-.welcome > .form > .buttons-container > .button[disabled] {
-    cursor: not-allowed;
-    opacity: 0.5;
-    -o-opacity: 0.5;
-    -ms-opacity: 0.5;
-    -moz-opacity: 0.5;
-    -khtml-opacity: 0.5;
-    -webkit-opacity: 0.5;
+.welcome .welcome-action-bar > .welcome-options {
+    display: flex;
+    flex: 1;
+    flex-wrap: wrap;
+    gap: 20px;
+    min-width: 0;
 }
 
-.welcome > .footer {
-    bottom: 0px;
-    font-size: 11px;
+.welcome .welcome-action-bar > .welcome-options > .option-group {
+    align-items: center;
+    display: flex;
+    gap: 10px;
+}
+
+.welcome .welcome-action-bar > .welcome-options > .option-group > .option-group-label {
+    color: #6b7280;
+    font-size: 10px;
     font-weight: 600;
-    height: 24px;
-    letter-spacing: 0.25px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+}
+
+.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip-input {
+    height: 0px;
+    margin: 0px 0px 0px 0px;
+    opacity: 0;
+    -o-opacity: 0;
+    -ms-opacity: 0;
+    -moz-opacity: 0;
+    -khtml-opacity: 0;
+    -webkit-opacity: 0;
+    pointer-events: none;
     position: absolute;
+    width: 0px;
+}
+
+.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip {
+    background-color: #f4f5f8;
+    border: 1px solid #e6e8ee;
+    border-radius: 999px 999px 999px 999px;
+    -o-border-radius: 999px 999px 999px 999px;
+    -ms-border-radius: 999px 999px 999px 999px;
+    -moz-border-radius: 999px 999px 999px 999px;
+    -khtml-border-radius: 999px 999px 999px 999px;
+    -webkit-border-radius: 999px 999px 999px 999px;
+    color: #4b5260;
+    cursor: pointer;
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.5px;
+    margin: 0px 0px 0px 0px;
+    min-width: 0px;
+    padding: 6px 12px 6px 12px;
+    transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    -o-transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    -ms-transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    -moz-transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    -khtml-transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    -webkit-transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip:hover {
+    border-color: #cfd4de;
+    color: #1f2330;
+}
+
+.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip-input:checked + .option-chip {
+    background-color: #1f2330;
+    border-color: #1f2330;
+    color: #ffffff;
+}
+
+.welcome .welcome-action-bar > .welcome-actions {
+    align-items: center;
+    display: flex;
+    flex: 0 0 auto;
+    gap: 8px;
+}
+
+.welcome .welcome-action-bar > .welcome-actions > .button {
+    min-width: 120px;
+}
+
+.welcome .welcome-action-bar > .welcome-actions > .button.button-ghost {
+    background-color: transparent;
+    border: 1px solid #d8dde6;
+    color: #4b5260;
+}
+
+.welcome .welcome-action-bar > .welcome-actions > .button.button-ghost:hover {
+    background-color: #f4f5f8;
+}
+
+.welcome .welcome-action-bar > .welcome-actions > .button[disabled] {
+    cursor: not-allowed;
+    opacity: 0.4;
+    -o-opacity: 0.4;
+    -ms-opacity: 0.4;
+    -moz-opacity: 0.4;
+    -khtml-opacity: 0.4;
+    -webkit-opacity: 0.4;
+    pointer-events: none;
+}
+
+.welcome .welcome-version {
+    color: #9aa0ad;
+    flex: 0 0 auto;
+    font-size: 9px;
+    font-weight: 500;
+    letter-spacing: 1px;
+    padding: 6px 48px 10px 48px;
     text-align: center;
     text-transform: uppercase;
-    width: 100%;
 }
 
 body.ldj .welcome {
     background-color: #faf8fc;
 }
 
-body.ldj .welcome > .form > .welcome-headline > .welcome-title {
+body.ldj .welcome .welcome-hero > .welcome-hero-eyebrow {
+    color: #9b87c2;
+}
+
+body.ldj .welcome .welcome-hero > .welcome-hero-title {
     color: #1f1430;
     font-weight: 200;
     letter-spacing: 1.5px;
     text-transform: uppercase;
 }
 
-body.ldj .welcome > .form > .welcome-headline > .welcome-subtitle {
-    color: #6b5a8a;
-    font-style: italic;
-    letter-spacing: 0.5px;
+body.ldj .welcome .welcome-hero > .welcome-hero-divider {
+    background-color: #c9b6e5;
 }
 
-body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card {
+body.ldj .welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card {
     border-color: #ece4f5;
 }
 
-body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card:hover {
+body.ldj .welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card:hover {
     border-color: #c9b6e5;
 }
 
-body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card.selected {
+body.ldj .welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card.selected {
     border-color: #9678d3;
+    box-shadow: 0px 4px 14px rgba(151, 120, 211, 0.18);
+    -o-box-shadow: 0px 4px 14px rgba(151, 120, 211, 0.18);
+    -ms-box-shadow: 0px 4px 14px rgba(151, 120, 211, 0.18);
+    -moz-box-shadow: 0px 4px 14px rgba(151, 120, 211, 0.18);
+    -khtml-box-shadow: 0px 4px 14px rgba(151, 120, 211, 0.18);
+    -webkit-box-shadow: 0px 4px 14px rgba(151, 120, 211, 0.18);
 }
 
-body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-image {
+body.ldj .welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card > .catalog-card-image {
     background-color: #f5f0fa;
 }
 
-body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-name {
+body.ldj .welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-name {
     color: #1f1430;
 }
 
-body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-meta {
+body.ldj .welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-meta {
+    color: #9b87c2;
+}
+
+body.ldj .welcome .welcome-action-bar {
+    border-top-color: #ece4f5;
+}
+
+body.ldj .welcome .welcome-action-bar > .welcome-options > .option-group > .option-group-label {
+    color: #9b87c2;
+}
+
+body.ldj .welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip {
+    background-color: #f5f0fa;
+    border-color: #ece4f5;
     color: #6b5a8a;
+}
+
+body.ldj .welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip:hover {
+    border-color: #c9b6e5;
+    color: #1f1430;
+}
+
+body.ldj .welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip-input:checked + .option-chip {
+    background-color: #9678d3;
+    border-color: #9678d3;
+    color: #ffffff;
+}
+
+body.ldj .welcome .welcome-action-bar > .welcome-actions > .button.button-ghost {
+    border-color: #ece4f5;
+    color: #6b5a8a;
+}
+
+body.ldj .welcome .welcome-action-bar > .welcome-actions > .button.button-ghost:hover {
+    background-color: #f5f0fa;
 }
 
 .collapsible > .collapsible-title {

--- a/static/css/bundle.css
+++ b/static/css/bundle.css
@@ -1189,16 +1189,8 @@ body.ldj .line {
     font-size: 10px;
     font-weight: 500;
     letter-spacing: 3px;
-    margin-bottom: 8px;
+    margin-bottom: 12px;
     text-transform: uppercase;
-}
-
-.welcome .welcome-hero > .welcome-hero-title {
-    color: #1f2330;
-    font-size: 24px;
-    font-weight: 300;
-    letter-spacing: 0.5px;
-    margin: 0px 0px 16px 0px;
 }
 
 .welcome .welcome-hero > .welcome-hero-divider {
@@ -1484,13 +1476,6 @@ body.ldj .welcome {
 
 body.ldj .welcome .welcome-hero > .welcome-hero-eyebrow {
     color: #9b87c2;
-}
-
-body.ldj .welcome .welcome-hero > .welcome-hero-title {
-    color: #1f1430;
-    font-weight: 200;
-    letter-spacing: 1.5px;
-    text-transform: uppercase;
 }
 
 body.ldj .welcome .welcome-hero > .welcome-hero-divider {

--- a/static/css/welcome.css
+++ b/static/css/welcome.css
@@ -66,16 +66,8 @@
     font-size: 10px;
     font-weight: 500;
     letter-spacing: 3px;
-    margin-bottom: 8px;
+    margin-bottom: 12px;
     text-transform: uppercase;
-}
-
-.welcome .welcome-hero > .welcome-hero-title {
-    color: #1f2330;
-    font-size: 24px;
-    font-weight: 300;
-    letter-spacing: 0.5px;
-    margin: 0px 0px 16px 0px;
 }
 
 .welcome .welcome-hero > .welcome-hero-divider {
@@ -361,13 +353,6 @@ body.ldj .welcome {
 
 body.ldj .welcome .welcome-hero > .welcome-hero-eyebrow {
     color: #9b87c2;
-}
-
-body.ldj .welcome .welcome-hero > .welcome-hero-title {
-    color: #1f1430;
-    font-weight: 200;
-    letter-spacing: 1.5px;
-    text-transform: uppercase;
 }
 
 body.ldj .welcome .welcome-hero > .welcome-hero-divider {

--- a/static/css/welcome.css
+++ b/static/css/welcome.css
@@ -312,7 +312,15 @@
 }
 
 .welcome .welcome-action-bar > .welcome-actions > .button {
+    box-sizing: border-box;
+    -o-box-sizing: border-box;
+    -ms-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    -khtml-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
     min-width: 120px;
+    text-align: center;
+    vertical-align: middle;
 }
 
 .welcome .welcome-action-bar > .welcome-actions > .button.button-ghost {

--- a/static/css/welcome.css
+++ b/static/css/welcome.css
@@ -1,0 +1,202 @@
+.welcome {
+    align-items: center;
+    background-color: #f4f7fa;
+    display: flex;
+    min-height: 100%;
+    padding: 48px 0px 64px 0px;
+}
+
+.welcome > .form.form-welcome {
+    max-width: 960px;
+    min-width: 720px;
+}
+
+.welcome > .form > .welcome-headline {
+    margin: 8px 0px 24px 0px;
+    text-align: center;
+}
+
+.welcome > .form > .welcome-headline > .welcome-title {
+    color: #2d2d2d;
+    font-size: 28px;
+    font-weight: 300;
+    letter-spacing: 0.5px;
+    margin: 0px 0px 8px 0px;
+}
+
+.welcome > .form > .welcome-headline > .welcome-subtitle {
+    color: #6b7280;
+    font-size: 14px;
+    font-weight: 400;
+    letter-spacing: 0.25px;
+    margin: 0px 0px 0px 0px;
+}
+
+.welcome > .form > .catalog-container {
+    margin: 0px 0px 24px 0px;
+}
+
+.welcome > .form > .catalog-container > .catalog {
+    -ms-grid-columns: 1fr 12px 1fr 12px 1fr;
+    display: -ms-grid;
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(3, 1fr);
+}
+
+.welcome > .form > .catalog-container > .catalog > .catalog-card {
+    background-color: #ffffff;
+    border: 2px solid #ececec;
+    border-radius: 6px 6px 6px 6px;
+    -o-border-radius: 6px 6px 6px 6px;
+    -ms-border-radius: 6px 6px 6px 6px;
+    -moz-border-radius: 6px 6px 6px 6px;
+    -khtml-border-radius: 6px 6px 6px 6px;
+    -webkit-border-radius: 6px 6px 6px 6px;
+    box-sizing: border-box;
+    -o-box-sizing: border-box;
+    -ms-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    -khtml-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    cursor: pointer;
+    overflow: hidden;
+    padding: 0px 0px 0px 0px;
+    text-align: center;
+    transition: border-color 0.2s ease, transform 0.2s ease;
+    -o-transition: border-color 0.2s ease, transform 0.2s ease;
+    -ms-transition: border-color 0.2s ease, transform 0.2s ease;
+    -moz-transition: border-color 0.2s ease, transform 0.2s ease;
+    -khtml-transition: border-color 0.2s ease, transform 0.2s ease;
+    -webkit-transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.welcome > .form > .catalog-container > .catalog > .catalog-card:hover {
+    border-color: #d0d0d0;
+    transform: translateY(-2px);
+    -o-transform: translateY(-2px);
+    -ms-transform: translateY(-2px);
+    -moz-transform: translateY(-2px);
+    -khtml-transform: translateY(-2px);
+    -webkit-transform: translateY(-2px);
+}
+
+.welcome > .form > .catalog-container > .catalog > .catalog-card.selected {
+    border-color: #2d2d2d;
+}
+
+.welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-image {
+    background-color: #f4f7fa;
+    background-position: center center;
+    background-repeat: no-repeat;
+    background-size: contain;
+    height: 160px;
+    width: 100%;
+}
+
+.welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body {
+    padding: 12px 12px 12px 12px;
+}
+
+.welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-name {
+    color: #2d2d2d;
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 0.25px;
+    margin: 0px 0px 4px 0px;
+}
+
+.welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-meta {
+    color: #6b7280;
+    font-size: 11px;
+    font-weight: 400;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+}
+
+.welcome > .form > .catalog-container > .catalog > .catalog-card.empty {
+    color: #6b7280;
+    cursor: default;
+    font-size: 13px;
+    font-weight: 400;
+    grid-column: 1 / -1;
+    padding: 32px 0px 32px 0px;
+    text-align: center;
+}
+
+.welcome > .form > .catalog-container > .catalog > .catalog-card.empty:hover {
+    border-color: #ececec;
+    transform: none;
+    -o-transform: none;
+    -ms-transform: none;
+    -moz-transform: none;
+    -khtml-transform: none;
+    -webkit-transform: none;
+}
+
+.welcome > .form > .buttons-container > .button-classic {
+    margin-left: 14px;
+}
+
+.welcome > .form > .buttons-container > .button[disabled] {
+    cursor: not-allowed;
+    opacity: 0.5;
+    -o-opacity: 0.5;
+    -ms-opacity: 0.5;
+    -moz-opacity: 0.5;
+    -khtml-opacity: 0.5;
+    -webkit-opacity: 0.5;
+}
+
+.welcome > .footer {
+    bottom: 0px;
+    font-size: 11px;
+    font-weight: 600;
+    height: 24px;
+    letter-spacing: 0.25px;
+    position: absolute;
+    text-align: center;
+    text-transform: uppercase;
+    width: 100%;
+}
+
+body.ldj .welcome {
+    background-color: #faf8fc;
+}
+
+body.ldj .welcome > .form > .welcome-headline > .welcome-title {
+    color: #1f1430;
+    font-weight: 200;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+}
+
+body.ldj .welcome > .form > .welcome-headline > .welcome-subtitle {
+    color: #6b5a8a;
+    font-style: italic;
+    letter-spacing: 0.5px;
+}
+
+body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card {
+    border-color: #ece4f5;
+}
+
+body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card:hover {
+    border-color: #c9b6e5;
+}
+
+body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card.selected {
+    border-color: #9678d3;
+}
+
+body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-image {
+    background-color: #f5f0fa;
+}
+
+body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-name {
+    color: #1f1430;
+}
+
+body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-meta {
+    color: #6b5a8a;
+}

--- a/static/css/welcome.css
+++ b/static/css/welcome.css
@@ -1,58 +1,120 @@
 .welcome {
-    align-items: center;
-    background-color: #f4f7fa;
+    background-color: #f8f9fb;
+    box-sizing: border-box;
+    -o-box-sizing: border-box;
+    -ms-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    -khtml-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
     display: flex;
-    min-height: 100%;
-    padding: 48px 0px 64px 0px;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+    width: 100%;
 }
 
 .welcome > .form.form-welcome {
-    max-width: 960px;
-    min-width: 720px;
+    background-color: transparent;
+    border-radius: 0px;
+    -o-border-radius: 0px;
+    -ms-border-radius: 0px;
+    -moz-border-radius: 0px;
+    -khtml-border-radius: 0px;
+    -webkit-border-radius: 0px;
+    box-shadow: none;
+    -o-box-shadow: none;
+    -ms-box-shadow: none;
+    -moz-box-shadow: none;
+    -khtml-box-shadow: none;
+    -webkit-box-shadow: none;
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    margin: 0px 0px 0px 0px;
+    max-width: none;
+    min-height: 0;
+    min-width: 0;
+    padding: 0px 0px 0px 0px;
+    width: 100%;
 }
 
-.welcome > .form > .welcome-headline {
-    margin: 8px 0px 24px 0px;
+.welcome .welcome-hero {
+    flex: 0 0 auto;
+    padding: 32px 48px 20px 48px;
     text-align: center;
 }
 
-.welcome > .form > .welcome-headline > .welcome-title {
+.welcome .welcome-hero > .welcome-hero-mark {
+    margin-bottom: 12px;
+}
+
+.welcome .welcome-hero > .welcome-hero-mark > .logo {
+    height: 28px;
+    width: auto;
+}
+
+.welcome .welcome-hero > .welcome-hero-mark > span.logo {
     color: #2d2d2d;
-    font-size: 28px;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+}
+
+.welcome .welcome-hero > .welcome-hero-eyebrow {
+    color: #9aa0ad;
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 3px;
+    margin-bottom: 8px;
+    text-transform: uppercase;
+}
+
+.welcome .welcome-hero > .welcome-hero-title {
+    color: #1f2330;
+    font-size: 24px;
     font-weight: 300;
     letter-spacing: 0.5px;
-    margin: 0px 0px 8px 0px;
+    margin: 0px 0px 16px 0px;
 }
 
-.welcome > .form > .welcome-headline > .welcome-subtitle {
-    color: #6b7280;
-    font-size: 14px;
-    font-weight: 400;
-    letter-spacing: 0.25px;
-    margin: 0px 0px 0px 0px;
+.welcome .welcome-hero > .welcome-hero-divider {
+    background-color: #d8dde6;
+    height: 1px;
+    margin: 0px auto 0px auto;
+    width: 48px;
 }
 
-.welcome > .form > .catalog-container {
-    margin: 0px 0px 24px 0px;
+.welcome .welcome-catalog {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: 8px 48px 8px 48px;
 }
 
-.welcome > .form > .catalog-container > .catalog {
-    -ms-grid-columns: 1fr 12px 1fr 12px 1fr;
+.welcome .welcome-catalog > .catalog-container {
+    margin: 0px auto 0px auto;
+    max-width: 1080px;
+}
+
+.welcome .welcome-catalog > .catalog-container > .catalog {
+    -ms-grid-columns: 1fr 12px 1fr 12px 1fr 12px 1fr;
     display: -ms-grid;
     display: grid;
     gap: 12px;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
 }
 
-.welcome > .form > .catalog-container > .catalog > .catalog-card {
+.welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card {
     background-color: #ffffff;
-    border: 2px solid #ececec;
-    border-radius: 6px 6px 6px 6px;
-    -o-border-radius: 6px 6px 6px 6px;
-    -ms-border-radius: 6px 6px 6px 6px;
-    -moz-border-radius: 6px 6px 6px 6px;
-    -khtml-border-radius: 6px 6px 6px 6px;
-    -webkit-border-radius: 6px 6px 6px 6px;
+    border: 1px solid #e6e8ee;
+    border-radius: 4px 4px 4px 4px;
+    -o-border-radius: 4px 4px 4px 4px;
+    -ms-border-radius: 4px 4px 4px 4px;
+    -moz-border-radius: 4px 4px 4px 4px;
+    -khtml-border-radius: 4px 4px 4px 4px;
+    -webkit-border-radius: 4px 4px 4px 4px;
     box-sizing: border-box;
     -o-box-sizing: border-box;
     -ms-box-sizing: border-box;
@@ -63,16 +125,22 @@
     overflow: hidden;
     padding: 0px 0px 0px 0px;
     text-align: center;
-    transition: border-color 0.2s ease, transform 0.2s ease;
-    -o-transition: border-color 0.2s ease, transform 0.2s ease;
-    -ms-transition: border-color 0.2s ease, transform 0.2s ease;
-    -moz-transition: border-color 0.2s ease, transform 0.2s ease;
-    -khtml-transition: border-color 0.2s ease, transform 0.2s ease;
-    -webkit-transition: border-color 0.2s ease, transform 0.2s ease;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    -o-transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    -ms-transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    -moz-transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    -khtml-transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    -webkit-transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
-.welcome > .form > .catalog-container > .catalog > .catalog-card:hover {
-    border-color: #d0d0d0;
+.welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card:hover {
+    border-color: #cfd4de;
+    box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.06);
+    -o-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.06);
+    -ms-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.06);
+    -moz-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.06);
+    -khtml-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.06);
+    -webkit-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.06);
     transform: translateY(-2px);
     -o-transform: translateY(-2px);
     -ms-transform: translateY(-2px);
@@ -81,51 +149,66 @@
     -webkit-transform: translateY(-2px);
 }
 
-.welcome > .form > .catalog-container > .catalog > .catalog-card.selected {
-    border-color: #2d2d2d;
+.welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card.selected {
+    border-color: #1f2330;
+    box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.1);
+    -o-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.1);
+    -ms-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.1);
+    -moz-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.1);
+    -khtml-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.1);
+    -webkit-box-shadow: 0px 4px 12px rgba(31, 35, 48, 0.1);
 }
 
-.welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-image {
-    background-color: #f4f7fa;
+.welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card > .catalog-card-image {
+    background-color: #f4f5f8;
     background-position: center center;
     background-repeat: no-repeat;
     background-size: contain;
-    height: 160px;
+    height: 110px;
     width: 100%;
 }
 
-.welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body {
-    padding: 12px 12px 12px 12px;
+.welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card > .catalog-card-body {
+    padding: 8px 8px 10px 8px;
 }
 
-.welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-name {
-    color: #2d2d2d;
-    font-size: 14px;
+.welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-name {
+    color: #1f2330;
+    font-size: 12px;
     font-weight: 600;
     letter-spacing: 0.25px;
-    margin: 0px 0px 4px 0px;
+    margin: 0px 0px 2px 0px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-meta {
-    color: #6b7280;
-    font-size: 11px;
-    font-weight: 400;
-    letter-spacing: 0.5px;
+.welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-meta {
+    color: #9aa0ad;
+    font-size: 9px;
+    font-weight: 500;
+    letter-spacing: 0.75px;
     text-transform: uppercase;
 }
 
-.welcome > .form > .catalog-container > .catalog > .catalog-card.empty {
-    color: #6b7280;
+.welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card.empty {
+    color: #9aa0ad;
     cursor: default;
-    font-size: 13px;
+    font-size: 12px;
     font-weight: 400;
     grid-column: 1 / -1;
     padding: 32px 0px 32px 0px;
     text-align: center;
 }
 
-.welcome > .form > .catalog-container > .catalog > .catalog-card.empty:hover {
-    border-color: #ececec;
+.welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card.empty:hover {
+    border-color: #e6e8ee;
+    box-shadow: none;
+    -o-box-shadow: none;
+    -ms-box-shadow: none;
+    -moz-box-shadow: none;
+    -khtml-box-shadow: none;
+    -webkit-box-shadow: none;
     transform: none;
     -o-transform: none;
     -ms-transform: none;
@@ -134,69 +217,223 @@
     -webkit-transform: none;
 }
 
-.welcome > .form > .buttons-container > .button-classic {
-    margin-left: 14px;
+.welcome .welcome-action-bar {
+    background-color: #ffffff;
+    border-top: 1px solid #e6e8ee;
+    box-sizing: border-box;
+    -o-box-sizing: border-box;
+    -ms-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    -khtml-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    display: flex;
+    flex: 0 0 auto;
+    flex-wrap: wrap;
+    gap: 16px;
+    padding: 16px 48px 16px 48px;
 }
 
-.welcome > .form > .buttons-container > .button[disabled] {
-    cursor: not-allowed;
-    opacity: 0.5;
-    -o-opacity: 0.5;
-    -ms-opacity: 0.5;
-    -moz-opacity: 0.5;
-    -khtml-opacity: 0.5;
-    -webkit-opacity: 0.5;
+.welcome .welcome-action-bar > .welcome-options {
+    display: flex;
+    flex: 1;
+    flex-wrap: wrap;
+    gap: 20px;
+    min-width: 0;
 }
 
-.welcome > .footer {
-    bottom: 0px;
-    font-size: 11px;
+.welcome .welcome-action-bar > .welcome-options > .option-group {
+    align-items: center;
+    display: flex;
+    gap: 10px;
+}
+
+.welcome .welcome-action-bar > .welcome-options > .option-group > .option-group-label {
+    color: #6b7280;
+    font-size: 10px;
     font-weight: 600;
-    height: 24px;
-    letter-spacing: 0.25px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+}
+
+.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip-input {
+    height: 0px;
+    margin: 0px 0px 0px 0px;
+    opacity: 0;
+    -o-opacity: 0;
+    -ms-opacity: 0;
+    -moz-opacity: 0;
+    -khtml-opacity: 0;
+    -webkit-opacity: 0;
+    pointer-events: none;
     position: absolute;
+    width: 0px;
+}
+
+.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip {
+    background-color: #f4f5f8;
+    border: 1px solid #e6e8ee;
+    border-radius: 999px 999px 999px 999px;
+    -o-border-radius: 999px 999px 999px 999px;
+    -ms-border-radius: 999px 999px 999px 999px;
+    -moz-border-radius: 999px 999px 999px 999px;
+    -khtml-border-radius: 999px 999px 999px 999px;
+    -webkit-border-radius: 999px 999px 999px 999px;
+    color: #4b5260;
+    cursor: pointer;
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.5px;
+    margin: 0px 0px 0px 0px;
+    min-width: 0px;
+    padding: 6px 12px 6px 12px;
+    transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    -o-transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    -ms-transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    -moz-transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    -khtml-transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    -webkit-transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip:hover {
+    border-color: #cfd4de;
+    color: #1f2330;
+}
+
+.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip-input:checked + .option-chip {
+    background-color: #1f2330;
+    border-color: #1f2330;
+    color: #ffffff;
+}
+
+.welcome .welcome-action-bar > .welcome-actions {
+    align-items: center;
+    display: flex;
+    flex: 0 0 auto;
+    gap: 8px;
+}
+
+.welcome .welcome-action-bar > .welcome-actions > .button {
+    min-width: 120px;
+}
+
+.welcome .welcome-action-bar > .welcome-actions > .button.button-ghost {
+    background-color: transparent;
+    border: 1px solid #d8dde6;
+    color: #4b5260;
+}
+
+.welcome .welcome-action-bar > .welcome-actions > .button.button-ghost:hover {
+    background-color: #f4f5f8;
+}
+
+.welcome .welcome-action-bar > .welcome-actions > .button[disabled] {
+    cursor: not-allowed;
+    opacity: 0.4;
+    -o-opacity: 0.4;
+    -ms-opacity: 0.4;
+    -moz-opacity: 0.4;
+    -khtml-opacity: 0.4;
+    -webkit-opacity: 0.4;
+    pointer-events: none;
+}
+
+.welcome .welcome-version {
+    color: #9aa0ad;
+    flex: 0 0 auto;
+    font-size: 9px;
+    font-weight: 500;
+    letter-spacing: 1px;
+    padding: 6px 48px 10px 48px;
     text-align: center;
     text-transform: uppercase;
-    width: 100%;
 }
 
 body.ldj .welcome {
     background-color: #faf8fc;
 }
 
-body.ldj .welcome > .form > .welcome-headline > .welcome-title {
+body.ldj .welcome .welcome-hero > .welcome-hero-eyebrow {
+    color: #9b87c2;
+}
+
+body.ldj .welcome .welcome-hero > .welcome-hero-title {
     color: #1f1430;
     font-weight: 200;
     letter-spacing: 1.5px;
     text-transform: uppercase;
 }
 
-body.ldj .welcome > .form > .welcome-headline > .welcome-subtitle {
-    color: #6b5a8a;
-    font-style: italic;
-    letter-spacing: 0.5px;
+body.ldj .welcome .welcome-hero > .welcome-hero-divider {
+    background-color: #c9b6e5;
 }
 
-body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card {
+body.ldj .welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card {
     border-color: #ece4f5;
 }
 
-body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card:hover {
+body.ldj .welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card:hover {
     border-color: #c9b6e5;
 }
 
-body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card.selected {
+body.ldj .welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card.selected {
     border-color: #9678d3;
+    box-shadow: 0px 4px 14px rgba(151, 120, 211, 0.18);
+    -o-box-shadow: 0px 4px 14px rgba(151, 120, 211, 0.18);
+    -ms-box-shadow: 0px 4px 14px rgba(151, 120, 211, 0.18);
+    -moz-box-shadow: 0px 4px 14px rgba(151, 120, 211, 0.18);
+    -khtml-box-shadow: 0px 4px 14px rgba(151, 120, 211, 0.18);
+    -webkit-box-shadow: 0px 4px 14px rgba(151, 120, 211, 0.18);
 }
 
-body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-image {
+body.ldj .welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card > .catalog-card-image {
     background-color: #f5f0fa;
 }
 
-body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-name {
+body.ldj .welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-name {
     color: #1f1430;
 }
 
-body.ldj .welcome > .form > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-meta {
+body.ldj .welcome .welcome-catalog > .catalog-container > .catalog > .catalog-card > .catalog-card-body > .catalog-card-meta {
+    color: #9b87c2;
+}
+
+body.ldj .welcome .welcome-action-bar {
+    border-top-color: #ece4f5;
+}
+
+body.ldj .welcome .welcome-action-bar > .welcome-options > .option-group > .option-group-label {
+    color: #9b87c2;
+}
+
+body.ldj .welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip {
+    background-color: #f5f0fa;
+    border-color: #ece4f5;
     color: #6b5a8a;
+}
+
+body.ldj .welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip:hover {
+    border-color: #c9b6e5;
+    color: #1f1430;
+}
+
+body.ldj .welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip-input:checked + .option-chip {
+    background-color: #9678d3;
+    border-color: #9678d3;
+    color: #ffffff;
+}
+
+body.ldj .welcome .welcome-action-bar > .welcome-actions > .button.button-ghost {
+    border-color: #ece4f5;
+    color: #6b5a8a;
+}
+
+body.ldj .welcome .welcome-action-bar > .welcome-actions > .button.button-ghost:hover {
+    background-color: #f5f0fa;
 }

--- a/static/js/bundle.js
+++ b/static/js/bundle.js
@@ -2041,15 +2041,18 @@ const countLines = function(text) {
                     catalog.append(card);
                 }
 
-                // pre-selects the first card so that the form is
-                // immediately submittable without an extra click
-                const firstKey = keys[0];
+                // pre-selects the previously chosen profile if one
+                // is still present in the catalog, falling back to
+                // the first card so that the form is immediately
+                // submittable without an extra click
+                const previousKey = profileInput.val();
+                const initialKey =
+                    previousKey && profiles[previousKey] ? previousKey : keys[0];
                 catalog
-                    .children(".catalog-card[data-profile=" + firstKey + "]")
+                    .children(".catalog-card[data-profile=" + initialKey + "]")
                     .addClass("selected");
-                context.data("_selected", firstKey);
-                profileInput.val(firstKey);
-                variantInput.val("");
+                context.data("_selected", initialKey);
+                profileInput.val(initialKey);
                 buttonStart.prop("disabled", false);
                 return;
             }

--- a/static/js/bundle.js
+++ b/static/js/bundle.js
@@ -1942,7 +1942,9 @@ const countLines = function(text) {
      *
      * Operates on a container element and discovers its children
      * (.catalog, .profile-input, .variant-input, .button-start) by
-     * class name convention.
+     * class name convention. On plain initialization the plugin
+     * fetches the available profiles from the server and populates
+     * the catalog automatically.
      *
      * Actions:
      *   "load"  - populates the catalog with the given profiles
@@ -1973,6 +1975,94 @@ const countLines = function(text) {
             };
         };
 
+        // populates the catalog of the given context with the
+        // provided profiles object and stores it for later lookup,
+        // rendering one card per profile entry with image and
+        // metadata and pre-selecting the previously chosen entry
+        const renderCatalog = function(context, profiles) {
+            const catalog = jQuery(".catalog", context);
+            const profileInput = jQuery(".profile-input", context);
+            const buttonStart = jQuery(".button-start", context);
+
+            context.data("_profiles", profiles);
+            catalog.empty();
+
+            const keys = Object.keys(profiles);
+            if (keys.length === 0) {
+                const empty = jQuery("<div></div>");
+                empty.addClass("catalog-card empty");
+                empty.text("No templates available.");
+                catalog.append(empty);
+                return;
+            }
+
+            for (const key of keys) {
+                const profile = profiles[key];
+                const card = jQuery("<div></div>");
+                card.addClass("catalog-card");
+                card.attr("data-profile", key);
+
+                // resolves the background image from the profile
+                // definition, falling back to a neutral surface
+                // when no image is available for the template
+                const image = jQuery("<div></div>");
+                image.addClass("catalog-card-image");
+                if (profile.background) {
+                    image.css(
+                        "background-image",
+                        "url(/static/profiles/" + profile.background + ")"
+                    );
+                }
+                card.append(image);
+
+                const body = jQuery("<div></div>");
+                body.addClass("catalog-card-body");
+
+                const name = jQuery("<div></div>");
+                name.addClass("catalog-card-name");
+                name.text(profile.name);
+                body.append(name);
+
+                const meta = jQuery("<div></div>");
+                meta.addClass("catalog-card-meta");
+                const unit = profile.unit || "mm";
+                meta.text(profile.width + "x" + profile.height + " " + unit);
+                body.append(meta);
+
+                card.append(body);
+                catalog.append(card);
+            }
+
+            // pre-selects the previously chosen profile if one
+            // is still present in the catalog, falling back to
+            // the first card so that the form is immediately
+            // submittable without an extra click
+            const previousKey = profileInput.val();
+            const initialKey =
+                previousKey && profiles[previousKey] ? previousKey : keys[0];
+            catalog
+                .children(".catalog-card[data-profile=" + initialKey + "]")
+                .addClass("selected");
+            context.data("_selected", initialKey);
+            profileInput.val(initialKey);
+            buttonStart.prop("disabled", false);
+        };
+
+        // fetches the available profiles from the server and
+        // populates the catalog of the given context, silently
+        // ignoring fetch errors so the welcome screen still
+        // renders without a populated catalog
+        const fetchProfiles = async function(context) {
+            try {
+                const response = await fetch("/profiles");
+                if (response.status !== 200) return;
+                const profiles = await response.json();
+                renderCatalog(context, profiles);
+            } catch (err) {
+                // silently ignores fetch errors
+            }
+        };
+
         // returns the current selection as an object with the
         // profile key and variant index values from the first
         // matched element only
@@ -1988,72 +2078,10 @@ const countLines = function(text) {
             const buttonStart = jQuery(".button-start", context);
 
             // populates the catalog with the given profiles object
-            // and stores it for later lookup, rendering one card
-            // per profile entry with image and metadata
+            // using the shared render routine, exposing the data
+            // sink path for callers that already have the profiles
             if (action === "load") {
-                const profiles = options.profiles;
-                context.data("_profiles", profiles);
-                catalog.empty();
-
-                const keys = Object.keys(profiles);
-                if (keys.length === 0) {
-                    const empty = jQuery("<div></div>");
-                    empty.addClass("catalog-card empty");
-                    empty.text("No templates available.");
-                    catalog.append(empty);
-                    return;
-                }
-
-                for (const key of keys) {
-                    const profile = profiles[key];
-                    const card = jQuery("<div></div>");
-                    card.addClass("catalog-card");
-                    card.attr("data-profile", key);
-
-                    // resolves the background image from the profile
-                    // definition, falling back to a neutral surface
-                    // when no image is available for the template
-                    const image = jQuery("<div></div>");
-                    image.addClass("catalog-card-image");
-                    if (profile.background) {
-                        image.css(
-                            "background-image",
-                            "url(/static/profiles/" + profile.background + ")"
-                        );
-                    }
-                    card.append(image);
-
-                    const body = jQuery("<div></div>");
-                    body.addClass("catalog-card-body");
-
-                    const name = jQuery("<div></div>");
-                    name.addClass("catalog-card-name");
-                    name.text(profile.name);
-                    body.append(name);
-
-                    const meta = jQuery("<div></div>");
-                    meta.addClass("catalog-card-meta");
-                    const unit = profile.unit || "mm";
-                    meta.text(profile.width + "x" + profile.height + " " + unit);
-                    body.append(meta);
-
-                    card.append(body);
-                    catalog.append(card);
-                }
-
-                // pre-selects the previously chosen profile if one
-                // is still present in the catalog, falling back to
-                // the first card so that the form is immediately
-                // submittable without an extra click
-                const previousKey = profileInput.val();
-                const initialKey =
-                    previousKey && profiles[previousKey] ? previousKey : keys[0];
-                catalog
-                    .children(".catalog-card[data-profile=" + initialKey + "]")
-                    .addClass("selected");
-                context.data("_selected", initialKey);
-                profileInput.val(initialKey);
-                buttonStart.prop("disabled", false);
+                renderCatalog(context, options.profiles);
                 return;
             }
 
@@ -2077,6 +2105,11 @@ const countLines = function(text) {
 
                 context.triggerHandler("template", [profile, key, null]);
             });
+
+            // fetches and populates the catalog automatically on
+            // plain initialization so callers do not need to
+            // manage the network request themselves
+            fetchProfiles(context);
         });
 
         return this;
@@ -2152,25 +2185,10 @@ jQuery(document).ready(function() {
     // profile and variant dropdown container
     profileSelector.profileselector();
 
-    // initializes the welcome plugin on the welcome
-    // screen template catalog container
+    // initializes the welcome plugin on the welcome screen
+    // template catalog container, which fetches and populates
+    // the available profiles from the server on its own
     welcomeContainer.welcome();
-
-    // fetches the available profiles from the server and
-    // populates the welcome screen template catalog with
-    // the results
-    const loadWelcomeProfiles = async function() {
-        try {
-            const response = await fetch("/profiles");
-            if (response.status !== 200) return;
-            const profiles = await response.json();
-            welcomeContainer.welcome("load", { profiles: profiles });
-        } catch (err) {
-            // silently ignores fetch errors so the welcome
-            // screen still renders without a populated catalog
-        }
-    };
-    loadWelcomeProfiles();
 
     const fontSizeContainer = jQuery(".font-size-container");
     const fontSizeRange = jQuery(".font-size-range");

--- a/static/js/bundle.js
+++ b/static/js/bundle.js
@@ -2010,7 +2010,7 @@ const countLines = function(text) {
                 if (profile.background) {
                     image.css(
                         "background-image",
-                        "url(/static/profiles/" + profile.background + ")"
+                        "url(/static/profiles/" + encodeURI(profile.background) + ")"
                     );
                 }
                 card.append(image);

--- a/static/js/bundle.js
+++ b/static/js/bundle.js
@@ -2108,6 +2108,7 @@ jQuery(document).ready(function() {
     const modalInstructionsTitle = jQuery(".modal-instructions-title");
     const modalInstructionsDescription = jQuery(".modal-instructions-description");
     const modalInstructionsImages = jQuery(".modal-instructions-images");
+    const welcomeContainer = jQuery(".form-welcome");
 
     // registers for the click operation on the raw profile
     // toggle link to show or hide the formatted JSON contents
@@ -2151,16 +2152,25 @@ jQuery(document).ready(function() {
     // profile and variant dropdown container
     profileSelector.profileselector();
 
-    // initializes the welcome plugin on the welcome screen
-    // and populates the template catalog with the available
-    // profiles fetched from the server
-    const welcomeContainer = jQuery(".form-welcome");
-    if (welcomeContainer.length > 0) {
-        welcomeContainer.welcome();
-        jQuery.getJSON("/profiles", function(profiles) {
+    // initializes the welcome plugin on the welcome
+    // screen template catalog container
+    welcomeContainer.welcome();
+
+    // fetches the available profiles from the server and
+    // populates the welcome screen template catalog with
+    // the results
+    const loadWelcomeProfiles = async function() {
+        try {
+            const response = await fetch("/profiles");
+            if (response.status !== 200) return;
+            const profiles = await response.json();
             welcomeContainer.welcome("load", { profiles: profiles });
-        });
-    }
+        } catch (err) {
+            // silently ignores fetch errors so the welcome
+            // screen still renders without a populated catalog
+        }
+    };
+    loadWelcomeProfiles();
 
     const fontSizeContainer = jQuery(".font-size-container");
     const fontSizeRange = jQuery(".font-size-range");

--- a/static/js/bundle.js
+++ b/static/js/bundle.js
@@ -1934,6 +1934,152 @@ const countLines = function(text) {
     };
 })(jQuery);
 
+(function(jQuery) {
+    /**
+     * Welcome plugin that renders an engraving template catalog
+     * with image cards and manages the template selection state
+     * for the welcome screen form.
+     *
+     * Operates on a container element and discovers its children
+     * (.catalog, .profile-input, .variant-input, .button-start) by
+     * class name convention.
+     *
+     * Actions:
+     *   "load"  - populates the catalog with the given profiles
+     *             object keyed by profile ID, rendering one card
+     *             per profile
+     *   "value" - returns the current selection as an object with
+     *             the profile key and variant index
+     *
+     * Events:
+     *   "template" - triggered when the template selection changes,
+     *                passing the profile, profile key, and variant
+     *                index as arguments
+     */
+    jQuery.fn.welcome = function(action, options) {
+        const elements = jQuery(this);
+
+        // resolves the current selection from the given context
+        // returning the profile, profile key, and variant index
+        const resolveSelection = function(context) {
+            const profiles = context.data("_profiles") || {};
+            const key = context.data("_selected") || null;
+            const variant = context.data("_variant");
+            const profile = key ? profiles[key] : null;
+            return {
+                profile: profile,
+                key: key,
+                variantIndex: variant === undefined || variant === null ? null : variant
+            };
+        };
+
+        // returns the current selection as an object with the
+        // profile key and variant index values from the first
+        // matched element only
+        if (action === "value") {
+            return resolveSelection(elements.first());
+        }
+
+        elements.each(function() {
+            const context = jQuery(this);
+            const catalog = jQuery(".catalog", context);
+            const profileInput = jQuery(".profile-input", context);
+            const variantInput = jQuery(".variant-input", context);
+            const buttonStart = jQuery(".button-start", context);
+
+            // populates the catalog with the given profiles object
+            // and stores it for later lookup, rendering one card
+            // per profile entry with image and metadata
+            if (action === "load") {
+                const profiles = options.profiles;
+                context.data("_profiles", profiles);
+                catalog.empty();
+
+                const keys = Object.keys(profiles);
+                if (keys.length === 0) {
+                    const empty = jQuery("<div></div>");
+                    empty.addClass("catalog-card empty");
+                    empty.text("No templates available.");
+                    catalog.append(empty);
+                    return;
+                }
+
+                for (const key of keys) {
+                    const profile = profiles[key];
+                    const card = jQuery("<div></div>");
+                    card.addClass("catalog-card");
+                    card.attr("data-profile", key);
+
+                    // resolves the background image from the profile
+                    // definition, falling back to a neutral surface
+                    // when no image is available for the template
+                    const image = jQuery("<div></div>");
+                    image.addClass("catalog-card-image");
+                    if (profile.background) {
+                        image.css(
+                            "background-image",
+                            "url(/static/profiles/" + profile.background + ")"
+                        );
+                    }
+                    card.append(image);
+
+                    const body = jQuery("<div></div>");
+                    body.addClass("catalog-card-body");
+
+                    const name = jQuery("<div></div>");
+                    name.addClass("catalog-card-name");
+                    name.text(profile.name);
+                    body.append(name);
+
+                    const meta = jQuery("<div></div>");
+                    meta.addClass("catalog-card-meta");
+                    const unit = profile.unit || "mm";
+                    meta.text(profile.width + "x" + profile.height + " " + unit);
+                    body.append(meta);
+
+                    card.append(body);
+                    catalog.append(card);
+                }
+
+                // pre-selects the first card so that the form is
+                // immediately submittable without an extra click
+                const firstKey = keys[0];
+                catalog
+                    .children(".catalog-card[data-profile=" + firstKey + "]")
+                    .addClass("selected");
+                context.data("_selected", firstKey);
+                profileInput.val(firstKey);
+                variantInput.val("");
+                buttonStart.prop("disabled", false);
+                return;
+            }
+
+            // registers for the click operation on each catalog
+            // card so that the selected template is reflected in
+            // the hidden form fields and visual selection state
+            catalog.on("click", ".catalog-card:not(.empty)", function() {
+                const card = jQuery(this);
+                const key = card.attr("data-profile");
+                const profiles = context.data("_profiles") || {};
+                const profile = profiles[key] || null;
+
+                catalog.children(".catalog-card").removeClass("selected");
+                card.addClass("selected");
+
+                context.data("_selected", key);
+                context.data("_variant", null);
+                profileInput.val(key);
+                variantInput.val("");
+                buttonStart.prop("disabled", false);
+
+                context.triggerHandler("template", [profile, key, null]);
+            });
+        });
+
+        return this;
+    };
+})(jQuery);
+
 jQuery(document).ready(function() {
     // runs a series of selections over the current viewport
     const body = jQuery("body");
@@ -2001,6 +2147,17 @@ jQuery(document).ready(function() {
     // initializes the profile selector plugin on the
     // profile and variant dropdown container
     profileSelector.profileselector();
+
+    // initializes the welcome plugin on the welcome screen
+    // and populates the template catalog with the available
+    // profiles fetched from the server
+    const welcomeContainer = jQuery(".form-welcome");
+    if (welcomeContainer.length > 0) {
+        welcomeContainer.welcome();
+        jQuery.getJSON("/profiles", function(profiles) {
+            welcomeContainer.welcome("load", { profiles: profiles });
+        });
+    }
 
     const fontSizeContainer = jQuery(".font-size-container");
     const fontSizeRange = jQuery(".font-size-range");

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -66,6 +66,17 @@ jQuery(document).ready(function() {
     // profile and variant dropdown container
     profileSelector.profileselector();
 
+    // initializes the welcome plugin on the welcome screen
+    // and populates the template catalog with the available
+    // profiles fetched from the server
+    const welcomeContainer = jQuery(".form-welcome");
+    if (welcomeContainer.length > 0) {
+        welcomeContainer.welcome();
+        jQuery.getJSON("/profiles", function(profiles) {
+            welcomeContainer.welcome("load", { profiles: profiles });
+        });
+    }
+
     const fontSizeContainer = jQuery(".font-size-container");
     const fontSizeRange = jQuery(".font-size-range");
     const fontSizeInput = jQuery(".font-size-input");

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -67,25 +67,10 @@ jQuery(document).ready(function() {
     // profile and variant dropdown container
     profileSelector.profileselector();
 
-    // initializes the welcome plugin on the welcome
-    // screen template catalog container
+    // initializes the welcome plugin on the welcome screen
+    // template catalog container, which fetches and populates
+    // the available profiles from the server on its own
     welcomeContainer.welcome();
-
-    // fetches the available profiles from the server and
-    // populates the welcome screen template catalog with
-    // the results
-    const loadWelcomeProfiles = async function() {
-        try {
-            const response = await fetch("/profiles");
-            if (response.status !== 200) return;
-            const profiles = await response.json();
-            welcomeContainer.welcome("load", { profiles: profiles });
-        } catch (err) {
-            // silently ignores fetch errors so the welcome
-            // screen still renders without a populated catalog
-        }
-    };
-    loadWelcomeProfiles();
 
     const fontSizeContainer = jQuery(".font-size-container");
     const fontSizeRange = jQuery(".font-size-range");

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -23,6 +23,7 @@ jQuery(document).ready(function() {
     const modalInstructionsTitle = jQuery(".modal-instructions-title");
     const modalInstructionsDescription = jQuery(".modal-instructions-description");
     const modalInstructionsImages = jQuery(".modal-instructions-images");
+    const welcomeContainer = jQuery(".form-welcome");
 
     // registers for the click operation on the raw profile
     // toggle link to show or hide the formatted JSON contents
@@ -66,16 +67,25 @@ jQuery(document).ready(function() {
     // profile and variant dropdown container
     profileSelector.profileselector();
 
-    // initializes the welcome plugin on the welcome screen
-    // and populates the template catalog with the available
-    // profiles fetched from the server
-    const welcomeContainer = jQuery(".form-welcome");
-    if (welcomeContainer.length > 0) {
-        welcomeContainer.welcome();
-        jQuery.getJSON("/profiles", function(profiles) {
+    // initializes the welcome plugin on the welcome
+    // screen template catalog container
+    welcomeContainer.welcome();
+
+    // fetches the available profiles from the server and
+    // populates the welcome screen template catalog with
+    // the results
+    const loadWelcomeProfiles = async function() {
+        try {
+            const response = await fetch("/profiles");
+            if (response.status !== 200) return;
+            const profiles = await response.json();
             welcomeContainer.welcome("load", { profiles: profiles });
-        });
-    }
+        } catch (err) {
+            // silently ignores fetch errors so the welcome
+            // screen still renders without a populated catalog
+        }
+    };
+    loadWelcomeProfiles();
 
     const fontSizeContainer = jQuery(".font-size-container");
     const fontSizeRange = jQuery(".font-size-range");

--- a/static/js/plugins/welcome.js
+++ b/static/js/plugins/welcome.js
@@ -6,7 +6,9 @@
      *
      * Operates on a container element and discovers its children
      * (.catalog, .profile-input, .variant-input, .button-start) by
-     * class name convention.
+     * class name convention. On plain initialization the plugin
+     * fetches the available profiles from the server and populates
+     * the catalog automatically.
      *
      * Actions:
      *   "load"  - populates the catalog with the given profiles
@@ -37,6 +39,94 @@
             };
         };
 
+        // populates the catalog of the given context with the
+        // provided profiles object and stores it for later lookup,
+        // rendering one card per profile entry with image and
+        // metadata and pre-selecting the previously chosen entry
+        const renderCatalog = function(context, profiles) {
+            const catalog = jQuery(".catalog", context);
+            const profileInput = jQuery(".profile-input", context);
+            const buttonStart = jQuery(".button-start", context);
+
+            context.data("_profiles", profiles);
+            catalog.empty();
+
+            const keys = Object.keys(profiles);
+            if (keys.length === 0) {
+                const empty = jQuery("<div></div>");
+                empty.addClass("catalog-card empty");
+                empty.text("No templates available.");
+                catalog.append(empty);
+                return;
+            }
+
+            for (const key of keys) {
+                const profile = profiles[key];
+                const card = jQuery("<div></div>");
+                card.addClass("catalog-card");
+                card.attr("data-profile", key);
+
+                // resolves the background image from the profile
+                // definition, falling back to a neutral surface
+                // when no image is available for the template
+                const image = jQuery("<div></div>");
+                image.addClass("catalog-card-image");
+                if (profile.background) {
+                    image.css(
+                        "background-image",
+                        "url(/static/profiles/" + profile.background + ")"
+                    );
+                }
+                card.append(image);
+
+                const body = jQuery("<div></div>");
+                body.addClass("catalog-card-body");
+
+                const name = jQuery("<div></div>");
+                name.addClass("catalog-card-name");
+                name.text(profile.name);
+                body.append(name);
+
+                const meta = jQuery("<div></div>");
+                meta.addClass("catalog-card-meta");
+                const unit = profile.unit || "mm";
+                meta.text(profile.width + "x" + profile.height + " " + unit);
+                body.append(meta);
+
+                card.append(body);
+                catalog.append(card);
+            }
+
+            // pre-selects the previously chosen profile if one
+            // is still present in the catalog, falling back to
+            // the first card so that the form is immediately
+            // submittable without an extra click
+            const previousKey = profileInput.val();
+            const initialKey =
+                previousKey && profiles[previousKey] ? previousKey : keys[0];
+            catalog
+                .children(".catalog-card[data-profile=" + initialKey + "]")
+                .addClass("selected");
+            context.data("_selected", initialKey);
+            profileInput.val(initialKey);
+            buttonStart.prop("disabled", false);
+        };
+
+        // fetches the available profiles from the server and
+        // populates the catalog of the given context, silently
+        // ignoring fetch errors so the welcome screen still
+        // renders without a populated catalog
+        const fetchProfiles = async function(context) {
+            try {
+                const response = await fetch("/profiles");
+                if (response.status !== 200) return;
+                const profiles = await response.json();
+                renderCatalog(context, profiles);
+            } catch (err) {
+                // silently ignores fetch errors
+            }
+        };
+
         // returns the current selection as an object with the
         // profile key and variant index values from the first
         // matched element only
@@ -52,72 +142,10 @@
             const buttonStart = jQuery(".button-start", context);
 
             // populates the catalog with the given profiles object
-            // and stores it for later lookup, rendering one card
-            // per profile entry with image and metadata
+            // using the shared render routine, exposing the data
+            // sink path for callers that already have the profiles
             if (action === "load") {
-                const profiles = options.profiles;
-                context.data("_profiles", profiles);
-                catalog.empty();
-
-                const keys = Object.keys(profiles);
-                if (keys.length === 0) {
-                    const empty = jQuery("<div></div>");
-                    empty.addClass("catalog-card empty");
-                    empty.text("No templates available.");
-                    catalog.append(empty);
-                    return;
-                }
-
-                for (const key of keys) {
-                    const profile = profiles[key];
-                    const card = jQuery("<div></div>");
-                    card.addClass("catalog-card");
-                    card.attr("data-profile", key);
-
-                    // resolves the background image from the profile
-                    // definition, falling back to a neutral surface
-                    // when no image is available for the template
-                    const image = jQuery("<div></div>");
-                    image.addClass("catalog-card-image");
-                    if (profile.background) {
-                        image.css(
-                            "background-image",
-                            "url(/static/profiles/" + profile.background + ")"
-                        );
-                    }
-                    card.append(image);
-
-                    const body = jQuery("<div></div>");
-                    body.addClass("catalog-card-body");
-
-                    const name = jQuery("<div></div>");
-                    name.addClass("catalog-card-name");
-                    name.text(profile.name);
-                    body.append(name);
-
-                    const meta = jQuery("<div></div>");
-                    meta.addClass("catalog-card-meta");
-                    const unit = profile.unit || "mm";
-                    meta.text(profile.width + "x" + profile.height + " " + unit);
-                    body.append(meta);
-
-                    card.append(body);
-                    catalog.append(card);
-                }
-
-                // pre-selects the previously chosen profile if one
-                // is still present in the catalog, falling back to
-                // the first card so that the form is immediately
-                // submittable without an extra click
-                const previousKey = profileInput.val();
-                const initialKey =
-                    previousKey && profiles[previousKey] ? previousKey : keys[0];
-                catalog
-                    .children(".catalog-card[data-profile=" + initialKey + "]")
-                    .addClass("selected");
-                context.data("_selected", initialKey);
-                profileInput.val(initialKey);
-                buttonStart.prop("disabled", false);
+                renderCatalog(context, options.profiles);
                 return;
             }
 
@@ -141,6 +169,11 @@
 
                 context.triggerHandler("template", [profile, key, null]);
             });
+
+            // fetches and populates the catalog automatically on
+            // plain initialization so callers do not need to
+            // manage the network request themselves
+            fetchProfiles(context);
         });
 
         return this;

--- a/static/js/plugins/welcome.js
+++ b/static/js/plugins/welcome.js
@@ -1,0 +1,145 @@
+(function(jQuery) {
+    /**
+     * Welcome plugin that renders an engraving template catalog
+     * with image cards and manages the template selection state
+     * for the welcome screen form.
+     *
+     * Operates on a container element and discovers its children
+     * (.catalog, .profile-input, .variant-input, .button-start) by
+     * class name convention.
+     *
+     * Actions:
+     *   "load"  - populates the catalog with the given profiles
+     *             object keyed by profile ID, rendering one card
+     *             per profile
+     *   "value" - returns the current selection as an object with
+     *             the profile key and variant index
+     *
+     * Events:
+     *   "template" - triggered when the template selection changes,
+     *                passing the profile, profile key, and variant
+     *                index as arguments
+     */
+    jQuery.fn.welcome = function(action, options) {
+        const elements = jQuery(this);
+
+        // resolves the current selection from the given context
+        // returning the profile, profile key, and variant index
+        const resolveSelection = function(context) {
+            const profiles = context.data("_profiles") || {};
+            const key = context.data("_selected") || null;
+            const variant = context.data("_variant");
+            const profile = key ? profiles[key] : null;
+            return {
+                profile: profile,
+                key: key,
+                variantIndex: variant === undefined || variant === null ? null : variant
+            };
+        };
+
+        // returns the current selection as an object with the
+        // profile key and variant index values from the first
+        // matched element only
+        if (action === "value") {
+            return resolveSelection(elements.first());
+        }
+
+        elements.each(function() {
+            const context = jQuery(this);
+            const catalog = jQuery(".catalog", context);
+            const profileInput = jQuery(".profile-input", context);
+            const variantInput = jQuery(".variant-input", context);
+            const buttonStart = jQuery(".button-start", context);
+
+            // populates the catalog with the given profiles object
+            // and stores it for later lookup, rendering one card
+            // per profile entry with image and metadata
+            if (action === "load") {
+                const profiles = options.profiles;
+                context.data("_profiles", profiles);
+                catalog.empty();
+
+                const keys = Object.keys(profiles);
+                if (keys.length === 0) {
+                    const empty = jQuery("<div></div>");
+                    empty.addClass("catalog-card empty");
+                    empty.text("No templates available.");
+                    catalog.append(empty);
+                    return;
+                }
+
+                for (const key of keys) {
+                    const profile = profiles[key];
+                    const card = jQuery("<div></div>");
+                    card.addClass("catalog-card");
+                    card.attr("data-profile", key);
+
+                    // resolves the background image from the profile
+                    // definition, falling back to a neutral surface
+                    // when no image is available for the template
+                    const image = jQuery("<div></div>");
+                    image.addClass("catalog-card-image");
+                    if (profile.background) {
+                        image.css(
+                            "background-image",
+                            "url(/static/profiles/" + profile.background + ")"
+                        );
+                    }
+                    card.append(image);
+
+                    const body = jQuery("<div></div>");
+                    body.addClass("catalog-card-body");
+
+                    const name = jQuery("<div></div>");
+                    name.addClass("catalog-card-name");
+                    name.text(profile.name);
+                    body.append(name);
+
+                    const meta = jQuery("<div></div>");
+                    meta.addClass("catalog-card-meta");
+                    const unit = profile.unit || "mm";
+                    meta.text(profile.width + "x" + profile.height + " " + unit);
+                    body.append(meta);
+
+                    card.append(body);
+                    catalog.append(card);
+                }
+
+                // pre-selects the first card so that the form is
+                // immediately submittable without an extra click
+                const firstKey = keys[0];
+                catalog
+                    .children(".catalog-card[data-profile=" + firstKey + "]")
+                    .addClass("selected");
+                context.data("_selected", firstKey);
+                profileInput.val(firstKey);
+                variantInput.val("");
+                buttonStart.prop("disabled", false);
+                return;
+            }
+
+            // registers for the click operation on each catalog
+            // card so that the selected template is reflected in
+            // the hidden form fields and visual selection state
+            catalog.on("click", ".catalog-card:not(.empty)", function() {
+                const card = jQuery(this);
+                const key = card.attr("data-profile");
+                const profiles = context.data("_profiles") || {};
+                const profile = profiles[key] || null;
+
+                catalog.children(".catalog-card").removeClass("selected");
+                card.addClass("selected");
+
+                context.data("_selected", key);
+                context.data("_variant", null);
+                profileInput.val(key);
+                variantInput.val("");
+                buttonStart.prop("disabled", false);
+
+                context.triggerHandler("template", [profile, key, null]);
+            });
+        });
+
+        return this;
+    };
+})(jQuery);

--- a/static/js/plugins/welcome.js
+++ b/static/js/plugins/welcome.js
@@ -105,15 +105,18 @@
                     catalog.append(card);
                 }
 
-                // pre-selects the first card so that the form is
-                // immediately submittable without an extra click
-                const firstKey = keys[0];
+                // pre-selects the previously chosen profile if one
+                // is still present in the catalog, falling back to
+                // the first card so that the form is immediately
+                // submittable without an extra click
+                const previousKey = profileInput.val();
+                const initialKey =
+                    previousKey && profiles[previousKey] ? previousKey : keys[0];
                 catalog
-                    .children(".catalog-card[data-profile=" + firstKey + "]")
+                    .children(".catalog-card[data-profile=" + initialKey + "]")
                     .addClass("selected");
-                context.data("_selected", firstKey);
-                profileInput.val(firstKey);
-                variantInput.val("");
+                context.data("_selected", initialKey);
+                profileInput.val(initialKey);
                 buttonStart.prop("disabled", false);
                 return;
             }

--- a/static/js/plugins/welcome.js
+++ b/static/js/plugins/welcome.js
@@ -74,7 +74,7 @@
                 if (profile.background) {
                     image.css(
                         "background-image",
-                        "url(/static/profiles/" + profile.background + ")"
+                        "url(/static/profiles/" + encodeURI(profile.background) + ")"
                     );
                 }
                 card.append(image);

--- a/views/gateway-pt_pt.ejs
+++ b/views/gateway-pt_pt.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt">
     <%- include("head"); -%>
     <body class="<%= theme %>" data-theme="<%= theme %>" data-master="<%= masterb64 %>">
         <div class="gateway">

--- a/views/gateway.ejs
+++ b/views/gateway.ejs
@@ -43,7 +43,7 @@
                     <label class="name">Technology</label>
                     <div class="value" id="technology">
                         <input class="radio" type="radio" id="diamond" name="technology" value="diamond"
-                            <%= config.technology === "diamond" ? "checked" : '' %>>
+                            <%= !config.technology || config.technology === "diamond" ? "checked" : '' %>>
                         <label class="radio-label" for="diamond">Diamond</label>
                         <input class="radio" type="radio" id="laser" name="technology" value="laser"
                             <%= config.technology === "laser" ? "checked" : '' %>>
@@ -60,7 +60,7 @@
                     <label class="name">Elements</label>
                     <div class="value" id="elements">
                         <input class="radio" type="radio" id="text" name="elements" value="text"
-                            <%= config.elements === "text" ? "checked" : '' %>>
+                            <%= !config.elements || config.elements === "text" ? "checked" : '' %>>
                         <label class="radio-label" for="text">Text</label>
                         <input class="radio" type="radio" id="calligraphy" name="elements" value="calligraphy"
                             <%= config.elements === "calligraphy" ? "checked" : '' %>>
@@ -77,7 +77,7 @@
                     <label class="name">Location</label>
                     <div class="value" id="location">
                         <input class="radio" type="radio" id="interior" name="location" value="interior"
-                            <%= config.location === "interior" ? "checked" : '' %>>
+                            <%= !config.location || config.location === "interior" ? "checked" : '' %>>
                         <label class="radio-label" for="interior">Interior</label>
                         <input class="radio" type="radio" id="exterior" name="location" value="exterior"
                             <%= config.location === "exterior" ? "checked" : '' %>>

--- a/views/gateway.ejs
+++ b/views/gateway.ejs
@@ -84,6 +84,7 @@
                         <label class="radio-label" for="exterior">Exterior</label>
                     </div>
                 </div>
+                <input type="hidden" name="entry" value="gateway" />
                 <div class="buttons-container">
                     <button type="submit" class="button">Submit</button>
                     <span class="button button-configure">Configure</span>

--- a/views/head.ejs
+++ b/views/head.ejs
@@ -17,6 +17,7 @@
         <link rel="stylesheet" type="text/css" href="/static/css/signature.css">
         <link rel="stylesheet" type="text/css" href="/static/css/text.css">
         <link rel="stylesheet" type="text/css" href="/static/css/viewport.css">
+        <link rel="stylesheet" type="text/css" href="/static/css/welcome.css">
         <link rel="stylesheet" type="text/css" href="/static/css/plugins/collapsible.css">
         <link rel="stylesheet" type="text/css" href="/static/css/plugins/console.css">
         <link rel="stylesheet" type="text/css" href="/static/css/plugins/inspiration.css">
@@ -40,6 +41,7 @@
         <script src="/static/js/plugins/texteditor.js"></script>
         <script src="/static/js/plugins/toast.js"></script>
         <script src="/static/js/plugins/viewportpreview.js"></script>
+        <script src="/static/js/plugins/welcome.js"></script>
         <script src="/static/js/main.js"></script>
     <% } else { %>
         <script src="/static/js/bundle.js"></script>

--- a/views/report-pt_pt.ejs
+++ b/views/report-pt_pt.ejs
@@ -4,7 +4,7 @@
     <body class="<%= theme %>" data-theme="<%= theme %>">
         <div class="header">
             <div class="buttons-left">
-                <a class="button button-small button-back" href="/">←</a>
+                <a class="button button-small button-back" href="<%= typeof back !== 'undefined' ? back : '/' %>">←</a>
             </div>
             <div class="buttons-right">
                 <a class="button button-receipt"

--- a/views/report-pt_pt.ejs
+++ b/views/report-pt_pt.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt">
     <%- include("head"); -%>
     <body class="<%= theme %>" data-theme="<%= theme %>">
         <div class="header">

--- a/views/report.ejs
+++ b/views/report.ejs
@@ -4,7 +4,7 @@
     <body class="<%= theme %>" data-theme="<%= theme %>">
         <div class="header">
             <div class="buttons-left">
-                <a class="button button-small button-back" href="/">←</a>
+                <a class="button button-small button-back" href="<%= typeof back !== 'undefined' ? back : '/' %>">←</a>
             </div>
             <div class="buttons-right">
                 <a class="button button-receipt"

--- a/views/signature.ejs
+++ b/views/signature.ejs
@@ -4,7 +4,7 @@
     <body class="<%= theme %>" data-theme="<%= theme %>">
         <div class="header">
             <div class="buttons-left">
-                <a class="button button-small button-back" href="/">←</a>
+                <a class="button button-small button-back" href="<%= typeof back !== 'undefined' ? back : '/' %>">←</a>
                 <span class="button button-clear">Clear</span>
             </div>
             <div class="buttons-right">

--- a/views/viewport.ejs
+++ b/views/viewport.ejs
@@ -5,7 +5,7 @@
     <body class="<%= theme %>" data-theme="<%= theme %>" data-master="<%= masterb64 %>">
         <div class="header">
             <div class="buttons-left">
-                <a class="button button-small button-back" href="/">←</a>
+                <a class="button button-small button-back" href="<%= typeof back !== 'undefined' ? back : '/' %>">←</a>
                 <span class="button button-clear">Clear</span>
             </div>
             <div class="buttons-right">

--- a/views/welcome-pt_pt.ejs
+++ b/views/welcome-pt_pt.ejs
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+    <%- include("head"); -%>
+    <body class="<%= theme %>" data-theme="<%= theme %>" data-master="<%= masterb64 %>">
+        <div class="welcome">
+            <form class="form form-welcome" method="post" action="/gateway">
+                <div class="welcome-hero">
+                    <div class="welcome-hero-mark">
+                        <% if (theme === "ldj") { %>
+                            <img class="logo" src="/static/images/logo.svg" />
+                        <% } else { %>
+                            <span class="logo">Signatur</span>
+                        <% } %>
+                    </div>
+                    <div class="welcome-hero-eyebrow">Estúdio de Gravação</div>
+                    <div class="welcome-hero-divider"></div>
+                </div>
+                <div class="welcome-catalog">
+                    <div class="catalog-container">
+                        <div class="catalog"></div>
+                    </div>
+                </div>
+                <input class="profile-input" type="hidden" name="profile" value="<%= config.profile ? config.profile : '' %>" />
+                <input class="variant-input" type="hidden" name="variant" value="<%= config.variant ? config.variant : '' %>" />
+                <input type="hidden" name="entry" value="welcome" />
+                <div class="welcome-action-bar">
+                    <div class="welcome-options">
+                        <div class="option-group">
+                            <span class="option-group-label">Tecnologia</span>
+                            <div class="option-chips" id="technology">
+                                <input class="option-chip-input" type="radio" id="diamond" name="technology" value="diamond"
+                                    <%= !config.technology || config.technology === "diamond" ? "checked" : '' %>>
+                                <label class="option-chip" for="diamond">Diamante</label>
+                                <input class="option-chip-input" type="radio" id="laser" name="technology" value="laser"
+                                    <%= config.technology === "laser" ? "checked" : '' %>>
+                                <label class="option-chip" for="laser">Laser</label>
+                                <input class="option-chip-input" type="radio" id="fresa" name="technology" value="fresa"
+                                    <%= config.technology === "fresa" ? "checked" : '' %>>
+                                <label class="option-chip" for="fresa">Fresa</label>
+                                <input class="option-chip-input" type="radio" id="pantograph" name="technology" value="pantograph"
+                                    <%= config.technology === "pantograph" ? "checked" : '' %>>
+                                <label class="option-chip" for="pantograph">Pantógrafo</label>
+                            </div>
+                        </div>
+                        <div class="option-group">
+                            <span class="option-group-label">Elementos</span>
+                            <div class="option-chips" id="elements">
+                                <input class="option-chip-input" type="radio" id="text" name="elements" value="text"
+                                    <%= !config.elements || config.elements === "text" ? "checked" : '' %>>
+                                <label class="option-chip" for="text">Texto</label>
+                                <input class="option-chip-input" type="radio" id="calligraphy" name="elements" value="calligraphy"
+                                    <%= config.elements === "calligraphy" ? "checked" : '' %>>
+                                <label class="option-chip" for="calligraphy">Caligrafia</label>
+                                <input class="option-chip-input" type="radio" id="digital-printing" name="elements" value="digital_printing"
+                                    <%= config.elements === "digital_printing" ? "checked" : '' %>>
+                                <label class="option-chip" for="digital-printing">Impr. digital</label>
+                                <input class="option-chip-input" type="radio" id="graphic-element" name="elements" value="graphic_element"
+                                    <%= config.elements === "graphic_element" ? "checked" : '' %>>
+                                <label class="option-chip" for="graphic-element">Gráfico</label>
+                            </div>
+                        </div>
+                        <div class="option-group">
+                            <span class="option-group-label">Localização</span>
+                            <div class="option-chips" id="location">
+                                <input class="option-chip-input" type="radio" id="interior" name="location" value="interior"
+                                    <%= !config.location || config.location === "interior" ? "checked" : '' %>>
+                                <label class="option-chip" for="interior">Interior</label>
+                                <input class="option-chip-input" type="radio" id="exterior" name="location" value="exterior"
+                                    <%= config.location === "exterior" ? "checked" : '' %>>
+                                <label class="option-chip" for="exterior">Exterior</label>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="welcome-actions">
+                        <a class="button button-ghost button-classic" href="/gateway">Clássico</a>
+                        <button type="submit" class="button button-start" disabled>Iniciar</button>
+                    </div>
+                </div>
+                <div class="welcome-version">
+                    <span>Versão <%= info.version %></span>
+                </div>
+            </form>
+        </div>
+    </body>
+</html>

--- a/views/welcome-pt_pt.ejs
+++ b/views/welcome-pt_pt.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt">
     <%- include("head"); -%>
     <body class="<%= theme %>" data-theme="<%= theme %>" data-master="<%= masterb64 %>">
         <div class="welcome">

--- a/views/welcome.ejs
+++ b/views/welcome.ejs
@@ -28,7 +28,7 @@
                             <span class="option-group-label">Technology</span>
                             <div class="option-chips" id="technology">
                                 <input class="option-chip-input" type="radio" id="diamond" name="technology" value="diamond"
-                                    <%= config.technology === "diamond" ? "checked" : '' %>>
+                                    <%= !config.technology || config.technology === "diamond" ? "checked" : '' %>>
                                 <label class="option-chip" for="diamond">Diamond</label>
                                 <input class="option-chip-input" type="radio" id="laser" name="technology" value="laser"
                                     <%= config.technology === "laser" ? "checked" : '' %>>
@@ -45,7 +45,7 @@
                             <span class="option-group-label">Elements</span>
                             <div class="option-chips" id="elements">
                                 <input class="option-chip-input" type="radio" id="text" name="elements" value="text"
-                                    <%= config.elements === "text" ? "checked" : '' %>>
+                                    <%= !config.elements || config.elements === "text" ? "checked" : '' %>>
                                 <label class="option-chip" for="text">Text</label>
                                 <input class="option-chip-input" type="radio" id="calligraphy" name="elements" value="calligraphy"
                                     <%= config.elements === "calligraphy" ? "checked" : '' %>>
@@ -62,7 +62,7 @@
                             <span class="option-group-label">Location</span>
                             <div class="option-chips" id="location">
                                 <input class="option-chip-input" type="radio" id="interior" name="location" value="interior"
-                                    <%= config.location === "interior" ? "checked" : '' %>>
+                                    <%= !config.location || config.location === "interior" ? "checked" : '' %>>
                                 <label class="option-chip" for="interior">Interior</label>
                                 <input class="option-chip-input" type="radio" id="exterior" name="location" value="exterior"
                                     <%= config.location === "exterior" ? "checked" : '' %>>

--- a/views/welcome.ejs
+++ b/views/welcome.ejs
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+    <%- include("head"); -%>
+    <body class="<%= theme %>" data-theme="<%= theme %>" data-master="<%= masterb64 %>">
+        <div class="welcome">
+            <form class="form form-welcome" method="post" action="/gateway">
+                <div class="logo-container">
+                    <% if (theme === "ldj") { %>
+                        <img class="logo" src="/static/images/logo.svg" />
+                    <% } else { %>
+                        <span class="logo">Welcome</span>
+                    <% } %>
+                </div>
+                <div class="welcome-headline">
+                    <h1 class="welcome-title">Choose a Template</h1>
+                    <p class="welcome-subtitle">Select an engraving template to begin.</p>
+                </div>
+                <div class="catalog-container">
+                    <div class="catalog"></div>
+                </div>
+                <input class="profile-input" type="hidden" name="profile" value="" />
+                <input class="variant-input" type="hidden" name="variant" value="" />
+                <div class="field">
+                    <label class="name">Technology</label>
+                    <div class="value" id="technology">
+                        <input class="radio" type="radio" id="diamond" name="technology" value="diamond"
+                            <%= config.technology === "diamond" ? "checked" : '' %>>
+                        <label class="radio-label" for="diamond">Diamond</label>
+                        <input class="radio" type="radio" id="laser" name="technology" value="laser"
+                            <%= config.technology === "laser" ? "checked" : '' %>>
+                        <label class="radio-label" for="laser">Laser</label>
+                        <input class="radio" type="radio" id="fresa" name="technology" value="fresa"
+                            <%= config.technology === "fresa" ? "checked" : '' %>>
+                        <label class="radio-label" for="fresa">Fresa</label>
+                        <input class="radio" type="radio" id="pantograph" name="technology" value="pantograph"
+                            <%= config.technology === "pantograph" ? "checked" : '' %>>
+                        <label class="radio-label" for="pantograph">Pantograph</label>
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="name">Elements</label>
+                    <div class="value" id="elements">
+                        <input class="radio" type="radio" id="text" name="elements" value="text"
+                            <%= config.elements === "text" ? "checked" : '' %>>
+                        <label class="radio-label" for="text">Text</label>
+                        <input class="radio" type="radio" id="calligraphy" name="elements" value="calligraphy"
+                            <%= config.elements === "calligraphy" ? "checked" : '' %>>
+                        <label class="radio-label" for="calligraphy">Calligraphy</label>
+                        <input class="radio" type="radio" id="digital-printing" name="elements" value="digital_printing"
+                            <%= config.elements === "digital_printing" ? "checked" : '' %>>
+                        <label class="radio-label" for="digital-printing">Dig. print</label>
+                        <input class="radio" type="radio" id="graphic-element" name="elements" value="graphic_element"
+                            <%= config.elements === "graphic_element" ? "checked" : '' %>>
+                        <label class="radio-label" for="graphic-element">Graphic element</label>
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="name">Location</label>
+                    <div class="value" id="location">
+                        <input class="radio" type="radio" id="interior" name="location" value="interior"
+                            <%= config.location === "interior" ? "checked" : '' %>>
+                        <label class="radio-label" for="interior">Interior</label>
+                        <input class="radio" type="radio" id="exterior" name="location" value="exterior"
+                            <%= config.location === "exterior" ? "checked" : '' %>>
+                        <label class="radio-label" for="exterior">Exterior</label>
+                    </div>
+                </div>
+                <div class="buttons-container">
+                    <button type="submit" class="button button-start" disabled>Start</button>
+                    <a class="button button-classic" href="/gateway">Classic</a>
+                </div>
+            </form>
+            <div class="footer">
+                <div class="version">
+                    Version <%= info.version %>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/views/welcome.ejs
+++ b/views/welcome.ejs
@@ -4,77 +4,82 @@
     <body class="<%= theme %>" data-theme="<%= theme %>" data-master="<%= masterb64 %>">
         <div class="welcome">
             <form class="form form-welcome" method="post" action="/gateway">
-                <div class="logo-container">
-                    <% if (theme === "ldj") { %>
-                        <img class="logo" src="/static/images/logo.svg" />
-                    <% } else { %>
-                        <span class="logo">Welcome</span>
-                    <% } %>
+                <div class="welcome-hero">
+                    <div class="welcome-hero-mark">
+                        <% if (theme === "ldj") { %>
+                            <img class="logo" src="/static/images/logo.svg" />
+                        <% } else { %>
+                            <span class="logo">Signatur</span>
+                        <% } %>
+                    </div>
+                    <div class="welcome-hero-eyebrow">Engraving Studio</div>
+                    <h1 class="welcome-hero-title">Choose a Template</h1>
+                    <div class="welcome-hero-divider"></div>
                 </div>
-                <div class="welcome-headline">
-                    <h1 class="welcome-title">Choose a Template</h1>
-                    <p class="welcome-subtitle">Select an engraving template to begin.</p>
-                </div>
-                <div class="catalog-container">
-                    <div class="catalog"></div>
+                <div class="welcome-catalog">
+                    <div class="catalog-container">
+                        <div class="catalog"></div>
+                    </div>
                 </div>
                 <input class="profile-input" type="hidden" name="profile" value="" />
                 <input class="variant-input" type="hidden" name="variant" value="" />
-                <div class="field">
-                    <label class="name">Technology</label>
-                    <div class="value" id="technology">
-                        <input class="radio" type="radio" id="diamond" name="technology" value="diamond"
-                            <%= config.technology === "diamond" ? "checked" : '' %>>
-                        <label class="radio-label" for="diamond">Diamond</label>
-                        <input class="radio" type="radio" id="laser" name="technology" value="laser"
-                            <%= config.technology === "laser" ? "checked" : '' %>>
-                        <label class="radio-label" for="laser">Laser</label>
-                        <input class="radio" type="radio" id="fresa" name="technology" value="fresa"
-                            <%= config.technology === "fresa" ? "checked" : '' %>>
-                        <label class="radio-label" for="fresa">Fresa</label>
-                        <input class="radio" type="radio" id="pantograph" name="technology" value="pantograph"
-                            <%= config.technology === "pantograph" ? "checked" : '' %>>
-                        <label class="radio-label" for="pantograph">Pantograph</label>
+                <div class="welcome-action-bar">
+                    <div class="welcome-options">
+                        <div class="option-group">
+                            <span class="option-group-label">Technology</span>
+                            <div class="option-chips" id="technology">
+                                <input class="option-chip-input" type="radio" id="diamond" name="technology" value="diamond"
+                                    <%= config.technology === "diamond" ? "checked" : '' %>>
+                                <label class="option-chip" for="diamond">Diamond</label>
+                                <input class="option-chip-input" type="radio" id="laser" name="technology" value="laser"
+                                    <%= config.technology === "laser" ? "checked" : '' %>>
+                                <label class="option-chip" for="laser">Laser</label>
+                                <input class="option-chip-input" type="radio" id="fresa" name="technology" value="fresa"
+                                    <%= config.technology === "fresa" ? "checked" : '' %>>
+                                <label class="option-chip" for="fresa">Fresa</label>
+                                <input class="option-chip-input" type="radio" id="pantograph" name="technology" value="pantograph"
+                                    <%= config.technology === "pantograph" ? "checked" : '' %>>
+                                <label class="option-chip" for="pantograph">Pantograph</label>
+                            </div>
+                        </div>
+                        <div class="option-group">
+                            <span class="option-group-label">Elements</span>
+                            <div class="option-chips" id="elements">
+                                <input class="option-chip-input" type="radio" id="text" name="elements" value="text"
+                                    <%= config.elements === "text" ? "checked" : '' %>>
+                                <label class="option-chip" for="text">Text</label>
+                                <input class="option-chip-input" type="radio" id="calligraphy" name="elements" value="calligraphy"
+                                    <%= config.elements === "calligraphy" ? "checked" : '' %>>
+                                <label class="option-chip" for="calligraphy">Calligraphy</label>
+                                <input class="option-chip-input" type="radio" id="digital-printing" name="elements" value="digital_printing"
+                                    <%= config.elements === "digital_printing" ? "checked" : '' %>>
+                                <label class="option-chip" for="digital-printing">Dig. print</label>
+                                <input class="option-chip-input" type="radio" id="graphic-element" name="elements" value="graphic_element"
+                                    <%= config.elements === "graphic_element" ? "checked" : '' %>>
+                                <label class="option-chip" for="graphic-element">Graphic</label>
+                            </div>
+                        </div>
+                        <div class="option-group">
+                            <span class="option-group-label">Location</span>
+                            <div class="option-chips" id="location">
+                                <input class="option-chip-input" type="radio" id="interior" name="location" value="interior"
+                                    <%= config.location === "interior" ? "checked" : '' %>>
+                                <label class="option-chip" for="interior">Interior</label>
+                                <input class="option-chip-input" type="radio" id="exterior" name="location" value="exterior"
+                                    <%= config.location === "exterior" ? "checked" : '' %>>
+                                <label class="option-chip" for="exterior">Exterior</label>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="welcome-actions">
+                        <a class="button button-ghost button-classic" href="/gateway">Classic</a>
+                        <button type="submit" class="button button-start" disabled>Start</button>
                     </div>
                 </div>
-                <div class="field">
-                    <label class="name">Elements</label>
-                    <div class="value" id="elements">
-                        <input class="radio" type="radio" id="text" name="elements" value="text"
-                            <%= config.elements === "text" ? "checked" : '' %>>
-                        <label class="radio-label" for="text">Text</label>
-                        <input class="radio" type="radio" id="calligraphy" name="elements" value="calligraphy"
-                            <%= config.elements === "calligraphy" ? "checked" : '' %>>
-                        <label class="radio-label" for="calligraphy">Calligraphy</label>
-                        <input class="radio" type="radio" id="digital-printing" name="elements" value="digital_printing"
-                            <%= config.elements === "digital_printing" ? "checked" : '' %>>
-                        <label class="radio-label" for="digital-printing">Dig. print</label>
-                        <input class="radio" type="radio" id="graphic-element" name="elements" value="graphic_element"
-                            <%= config.elements === "graphic_element" ? "checked" : '' %>>
-                        <label class="radio-label" for="graphic-element">Graphic element</label>
-                    </div>
-                </div>
-                <div class="field">
-                    <label class="name">Location</label>
-                    <div class="value" id="location">
-                        <input class="radio" type="radio" id="interior" name="location" value="interior"
-                            <%= config.location === "interior" ? "checked" : '' %>>
-                        <label class="radio-label" for="interior">Interior</label>
-                        <input class="radio" type="radio" id="exterior" name="location" value="exterior"
-                            <%= config.location === "exterior" ? "checked" : '' %>>
-                        <label class="radio-label" for="exterior">Exterior</label>
-                    </div>
-                </div>
-                <div class="buttons-container">
-                    <button type="submit" class="button button-start" disabled>Start</button>
-                    <a class="button button-classic" href="/gateway">Classic</a>
+                <div class="welcome-version">
+                    <span>Version <%= info.version %></span>
                 </div>
             </form>
-            <div class="footer">
-                <div class="version">
-                    Version <%= info.version %>
-                </div>
-            </div>
         </div>
     </body>
 </html>

--- a/views/welcome.ejs
+++ b/views/welcome.ejs
@@ -20,8 +20,9 @@
                         <div class="catalog"></div>
                     </div>
                 </div>
-                <input class="profile-input" type="hidden" name="profile" value="" />
-                <input class="variant-input" type="hidden" name="variant" value="" />
+                <input class="profile-input" type="hidden" name="profile" value="<%= config.profile ? config.profile : '' %>" />
+                <input class="variant-input" type="hidden" name="variant" value="<%= config.variant ? config.variant : '' %>" />
+                <input type="hidden" name="entry" value="welcome" />
                 <div class="welcome-action-bar">
                     <div class="welcome-options">
                         <div class="option-group">

--- a/views/welcome.ejs
+++ b/views/welcome.ejs
@@ -13,7 +13,6 @@
                         <% } %>
                     </div>
                     <div class="welcome-hero-eyebrow">Engraving Studio</div>
-                    <h1 class="welcome-hero-title">Choose a Template</h1>
                     <div class="welcome-hero-divider"></div>
                 </div>
                 <div class="welcome-catalog">


### PR DESCRIPTION
Closes #21

## Summary

First bite at #21. Adds a new `/welcome` entry point that lets users land on a visual template catalog before the editor, while preserving every feature of the classic gateway (technology / elements / location, plus the existing routing into text / calligraphy / digital print / graphic element flows).

- **New route `/welcome`** in [app.js](app.js) that renders the welcome screen, sharing the same session/theme/locale handling as `/gateway`.
- **New view `views/welcome.ejs`** mirroring the gateway form structure (logo, fields, footer) and adding a visual catalog of template cards plus a "Classic" link back to `/gateway` for direct access to the original form.
- **New jQuery plugin `static/js/plugins/welcome.js`** following AGENTS.md conventions (IIFE, `jQuery.fn`, `/** */` docstring with Actions / Events). Actions: `load`, `value`. Event: `template`.
- **New stylesheet `static/css/welcome.css`** with a neutral default look and an LDJ-themed boutique variant inspired by lugardajoia.com (lighter background, uppercase serif-like title, purple accent border on selection).
- **Gateway POST extended** to forward optional `profile` and `variant` form fields as query parameters on the redirect so the editor automatically pre-selects the chosen template (the editor already supports `?profile=...&variant=...`).
- **Build registration**: `welcome.css` and `welcome.js` added to [scripts/build.js](scripts/build.js) and dev mode `<head>` in [views/head.ejs](views/head.ejs).
- **CHANGELOG.md** updated under `[Unreleased]`.

The welcome screen is **opt-in** for now: `/` and `/gateway` continue to serve the classic gateway unchanged. Switching `/` to render `/welcome` is intentionally deferred to a follow-up so we can iterate on UX without disrupting existing users.

## Out of scope (follow-ups)

- Switch `/` to render the welcome screen by default.
- Investigate / document Omni integration for a remote-backed template catalog (the optional task in #21).
- Card swipe / pagination for large catalogs (current grid is fine for the existing ~7 profiles).
- Per-template imagery curation — today the catalog reuses each profile's existing `background` image; profiles without one render on a neutral surface.

## Test plan

- [ ] `npm run build` — bundles rebuilt cleanly (14 CSS + 13 JS files)
- [ ] `npm run lint` — passes
- [ ] `npm test` — 96 tests pass
- [ ] Visit `/welcome` — catalog renders one card per profile with image, name, and dimensions
- [ ] Click a card — selection state updates and Start button enables
- [ ] Submit with Text + a selected template — lands on `/viewport` with the profile pre-selected
- [ ] Submit with Calligraphy — lands on `/signature` (template still forwarded as query string)
- [ ] Submit with Digital print or Graphic element — lands on `/report`
- [ ] Confirm `/` and `/gateway` still serve the classic gateway unchanged
- [ ] Visual check on default theme and `?theme=ldj` for the boutique variant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Welcome screen and route with a visual template catalog and selectable profiles
  * Welcome UI initialized on page load and supports restoring prior selection and pre-selection via query parameters
  * Portuguese localized welcome views

* **Bug Fixes**
  * Fixed document language for Portuguese views
  * Fixed catalog background-image URL encoding to avoid malformed CSS

* **Style**
  * Added welcome-specific styles and themed variants
<!-- end of auto-generated comment: release notes by coderabbit.ai -->