### PR TITLE
docs: document HTTP query parameters and clarify Colony Print env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Session-tracked entry point so the back arrow in the viewport, signature, and report views returns to the welcome screen or classic gateway depending on where the user came from
 * Restoration of the previously selected template card on the welcome catalog when navigating back from the editor
 * Portuguese (`pt_pt`) translation of the welcome screen mirroring the existing `welcome.ejs` layout
+* Documentation of the supported HTTP query parameters in `README.md`, grouped per route with type, default, and description columns
+* White background on the welcome screen version footer so it visually matches the action bar above it
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Portuguese (`pt_pt`) translation of the welcome screen mirroring the existing `welcome.ejs` layout
 * Documentation of the supported HTTP query parameters in `README.md`, grouped per route with type, default, and description columns
 * White background on the welcome screen version footer so it visually matches the action bar above it
+* Settings page at `/settings` for selecting the session-persisted `theme`, `locale`, and `fullscreen` values, with a Portuguese translation and a link from the welcome screen action bar
+* Session-persisted `home` preference selecting whether the bare `/` URL redirects to the classic gateway or to the welcome screen, defaulting to gateway
+* Session-persisted `show_options` preference toggling whether the technology, elements, and location selectors are rendered on the welcome screen and classic gateway, defaulting to on; when off the previously selected values are submitted via hidden inputs so the form still routes correctly
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,23 @@ Supported file format include:
 
 ## Query Parameters
 
-The following query parameters are honored by the Signatur HTTP routes. Most of them are also persisted on the user session (`theme`, `locale`, `text`) or restored from the URL on page load (viewport editor state) so they survive navigation.
+The following query parameters are honored by the Signatur HTTP routes. Some of them are also persisted on the user session so they survive navigation (`theme`, `locale`, `text`); others live exclusively on the URL and are either round-tripped by the client (viewport editor state) or only read once per request (`fullscreen`, `engine`, `format`).
+
+### Session persistence
+
+| Parameter      | Session-persisted | Notes                                                                                                                              |
+| -------------- | :---------------: | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `theme`        |        yes        | Written to `req.session.theme` on every page that reads it except `/console`, which reads but does not write.                      |
+| `locale`       |        yes        | Written to `req.session.locale` on every page that reads it.                                                                       |
+| `text`         |        yes        | Written to `req.session.config.text` on every page that reads it.                                                                  |
+| `home`         |        yes        | Set via the `/settings` POST body. Controls whether `/` redirects to `/gateway` (default) or `/welcome`.                           |
+| `show_options` |        yes        | Set via the `/settings` POST body. Controls whether the technology / elements / location selectors render on welcome and gateway.  |
+| `fullscreen`   |        no         | Only read per-request via `req.query.fullscreen === "1"`. Preserved across navigation by the viewport editor through the URL only. |
+| `profile`      |        no         | Stored on the session via the `/gateway` POST body (form field), then forwarded as a query string to the editor on redirect.       |
+| `variant`      |        no         | Same handling as `profile`.                                                                                                        |
+| editor state   |        no         | `font`, `font_size`, `font_size_mode`, `zoom`, `margins`, `rulers`, `crosshair`, `keyboard`, `guidelines`, `caret` are URL-only.   |
+| `engine`       |        no         | Read once per `/convert` POST.                                                                                                     |
+| `format`       |        no         | Read once per `/convert` POST.                                                                                                     |
 
 ### Theme and locale
 
@@ -50,7 +66,7 @@ The following query parameters are honored by the Signatur HTTP routes. Most of 
 | ------------ | ----- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `theme`      | `str` | `""`    | Visual theme identifier applied to the body (e.g. `ldj`). Persisted on the session for subsequent requests.                                |
 | `locale`     | `str` | `""`    | Locale identifier used to pick a localized view (e.g. `pt_pt`). Persisted on the session and used to load the matching `*-${locale}.ejs`.  |
-| `fullscreen` | `str` | `"0"`   | When set to `"1"`, enables the `apple-mobile-web-app-capable` meta. The viewport editor preserves the value across `history.replaceState`. |
+| `fullscreen` | `str` | `"0"`   | When set to `"1"`, enables the `apple-mobile-web-app-capable` meta. URL-only (not session-persisted).                                      |
 
 ### Text payload (`/viewport`, `/report`, `/text`, `/image`, `/receipt`)
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Supported file format include:
 | `BASE_URL`      | `str` | `http://localhost:3000`              | The base URL that is going to be used in the construction of external URLs for Signatur.                               |
 | `SIGNATUR_KEY`  | `str` | `None`                               | Secret key that should be passed in protected calls so that the server side "trusts" the client side (authentication). |
 | `HEADLESS_URL`  | `str` | `https://headless.stage.hive.pt`     | The base URL to be used to access [Headless](https://github.com/hivesolutions/headless).                               |
-| `PRINT_URL`     | `str` | `https://colony-print.stage.hive.pt` | The base URL to be used to access [Colony Print](http://colony-print.hive.pt).                                         |
-| `PRINT_NODE`    | `str` | `default`                            | The name of the print node to be used when accessing Colony Print.                                                     |
-| `PRINT_PRINTER` | `str` | `printer`                            | The name of printer (within print node) to be used by Colony Print.                                                    |
-| `PRINT_KEY`     | `str` | `null`                               | The secret key to be used when accessing Colony Print service.                                                         |
+| `PRINT_URL`     | `str` | `https://colony-print.stage.hive.pt` | Base URL of the [Colony Print](http://colony-print.hive.pt) service used when printing the report receipt.             |
+| `PRINT_NODE`    | `str` | `default`                            | Name of the Colony Print node to use when printing the report receipt.                                                 |
+| `PRINT_PRINTER` | `str` | `printer`                            | Name of the printer (within the print node) to use when printing the report receipt.                                   |
+| `PRINT_KEY`     | `str` | `null`                               | Secret key used to authenticate against Colony Print when printing the report receipt.                                 |
 
 ## Query Parameters
 
@@ -129,7 +129,6 @@ Signatur is currently licensed under the [Apache License, Version 2.0](http://ww
 
 ## Build Automation
 
-[![Build Status](https://app.travis-ci.com/hivesolutions/signatur.svg?branch=master)](https://travis-ci.com/github/hivesolutions/signatur)
-[![Build Status GitHub](https://github.com/hivesolutions/signatur/workflows/Main%20Workflow/badge.svg)](https://github.com/hivesolutions/signatur/actions)
+[![Build Status](https://github.com/hivesolutions/signatur/workflows/Main%20Workflow/badge.svg)](https://github.com/hivesolutions/signatur/actions)
 [![npm Status](https://img.shields.io/npm/v/signatur.svg)](https://www.npmjs.com/package/signatur)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://www.apache.org/licenses/)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,69 @@ Supported file format include:
 | `PRINT_PRINTER` | `str` | `printer`                            | The name of printer (within print node) to be used by Colony Print.                                                    |
 | `PRINT_KEY`     | `str` | `null`                               | The secret key to be used when accessing Colony Print service.                                                         |
 
+## Query Parameters
+
+The following query parameters are honored by the Signatur HTTP routes. Most of them are also persisted on the user session (`theme`, `locale`, `text`) or restored from the URL on page load (viewport editor state) so they survive navigation.
+
+### Theme and locale
+
+| Route        | `theme` | `locale` | `fullscreen` |
+| ------------ | :-----: | :------: | :----------: |
+| `/`          |   yes   |   yes    |     yes      |
+| `/gateway`   |   yes   |   yes    |     yes      |
+| `/welcome`   |   yes   |   yes    |     yes      |
+| `/signature` |   yes   |    -     |     yes      |
+| `/viewport`  |   yes   |    -     |     yes      |
+| `/report`    |   yes   |   yes    |     yes      |
+| `/console`   |   yes   |    -     |      -       |
+| `/receipt`   |    -    |   yes    |      -       |
+| `/image`     |    -    |   yes    |      -       |
+
+| Name         | Type  | Default | Description                                                                                                                                |
+| ------------ | ----- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `theme`      | `str` | `""`    | Visual theme identifier applied to the body (e.g. `ldj`). Persisted on the session for subsequent requests.                                |
+| `locale`     | `str` | `""`    | Locale identifier used to pick a localized view (e.g. `pt_pt`). Persisted on the session and used to load the matching `*-${locale}.ejs`.  |
+| `fullscreen` | `str` | `"0"`   | When set to `"1"`, enables the `apple-mobile-web-app-capable` meta. The viewport editor preserves the value across `history.replaceState`. |
+
+### Text payload (`/viewport`, `/report`, `/text`, `/image`, `/receipt`)
+
+| Name   | Type  | Default | Description                                                                                                                |
+| ------ | ----- | ------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `text` | `str` | `null`  | Serialized text payload to seed the editor or render with (`font/character` pairs). Persisted on the session config field. |
+
+### Template pre-selection (`/viewport`, `/report`)
+
+Forwarded automatically by the gateway POST when the welcome screen is used, but they can also be passed directly to deep-link into the editor with a specific template.
+
+| Name      | Type  | Default | Description                                                                                        |
+| --------- | ----- | ------- | -------------------------------------------------------------------------------------------------- |
+| `profile` | `str` | `null`  | Profile ID (matches a file under `static/profiles/*.json`) to pre-select in the profile dropdown.  |
+| `variant` | `str` | `null`  | Index of the variant to pre-select within the chosen profile, applied after `profile` is restored. |
+
+### Viewport editor state (`/viewport`)
+
+Read by the client and written back via `history.replaceState` so the editor URL always reflects the current state and can be shared or reloaded.
+
+| Name             | Type  | Default | Description                                                                                             |
+| ---------------- | ----- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `font`           | `str` | `null`  | Currently selected font name; restored by clicking the matching font element on load.                   |
+| `font_size`      | `int` | `null`  | Manual font size in profile units; applied to both the slider and the number input.                     |
+| `font_size_mode` | `str` | `null`  | Either `manual` or `automatic` for the font size mode toggle.                                           |
+| `zoom`           | `int` | `null`  | Zoom percentage applied to the viewport preview; clamped to the slider's min/max range.                 |
+| `margins`        | `str` | `null`  | Four comma-separated values (`left,right,top,bottom`) overriding the profile padding, in profile units. |
+| `rulers`         | `str` | `"1"`   | When `"0"` hides the horizontal and vertical rulers; any other value (or absent) keeps them visible.    |
+| `crosshair`      | `str` | `"1"`   | When `"0"` disables the hover crosshair lines on the viewport preview.                                  |
+| `keyboard`       | `str` | `"1"`   | When `"0"` hides the visual keyboard panel until re-toggled.                                            |
+| `guidelines`     | `str` | `"1"`   | When `"0"` hides the SVG profile bounds and safe area outlines on the preview.                          |
+| `caret`          | `str` | `"1"`   | When `"0"` hides the blinking caret in the viewport preview.                                            |
+
+### `/convert`
+
+| Name     | Type  | Default      | Description                                                                              |
+| -------- | ----- | ------------ | ---------------------------------------------------------------------------------------- |
+| `engine` | `str` | `"inkscape"` | Conversion engine identifier; resolved against the registered engines (e.g. `inkscape`). |
+| `format` | `str` | `"hpgl"`     | Target output format honored by the inkscape engine; one of `svg`, `pdf`, or `hpgl`.     |
+
 ## Printing
 
 To be able to enable printing the following JavaScript code should be used inside Browser's JavaScript console:

--- a/app.js
+++ b/app.js
@@ -55,7 +55,15 @@ app.locals.dev = process.env.NODE_ENV !== "production";
 app.use("/static", express.static(path.join(__dirname, "static")));
 app.use(bodyParser.urlencoded({ extended: true }));
 
-app.get(["/", "/gateway"], (req, res, next) => {
+app.get("/", (req, res, next) => {
+    // forwards the bare root URL to the user's preferred home
+    // landing page, defaulting to the classic gateway when no
+    // explicit preference has been stored on the session yet
+    const home = req.session.home === "welcome" ? "/welcome" : "/gateway";
+    res.redirect(302, home);
+});
+
+app.get("/gateway", (req, res, next) => {
     const fullscreen = req.query.fullscreen === "1";
     const theme = req.query.theme || req.session.theme || "";
     const locale = req.query.locale || req.session.locale || "";
@@ -67,6 +75,7 @@ app.get(["/", "/gateway"], (req, res, next) => {
         master: master,
         masterb64: masterb64,
         config: req.session.config || {},
+        showOptions: req.session.show_options !== "0",
         info: info || {}
     });
 });
@@ -103,6 +112,55 @@ app.post("/gateway", (req, res, next) => {
     }
 });
 
+app.get("/settings", (req, res, next) => {
+    const fullscreen = req.query.fullscreen === "1";
+    const theme = req.query.theme || req.session.theme || "";
+    const locale = req.query.locale || req.session.locale || "";
+    req.session.theme = theme;
+    req.session.locale = locale;
+
+    // resolves the next URL to redirect to after saving so the user
+    // returns to the screen they came from instead of always landing
+    // on the welcome page
+    const nextUrl = typeof req.query.next === "string" ? req.query.next : "";
+    res.render("settings" + (locale ? `-${locale}` : ""), {
+        fullscreen: fullscreen,
+        theme: theme,
+        locale: locale,
+        home: req.session.home === "welcome" ? "welcome" : "gateway",
+        showOptions: req.session.show_options !== "0",
+        next: nextUrl,
+        info: info || {}
+    });
+});
+
+app.post("/settings", (req, res, next) => {
+    const theme = req.body.theme || "";
+    const locale = req.body.locale || "";
+    req.session.theme = theme;
+    req.session.locale = locale;
+    req.session.home = req.body.home === "welcome" ? "welcome" : "gateway";
+    req.session.show_options = req.body.show_options === "0" ? "0" : "1";
+
+    // resolves the redirect target from the submitted next field
+    // restricting it to local paths so the form cannot be used as
+    // an open redirect
+    const target =
+        typeof req.body.next === "string" && req.body.next.startsWith("/")
+            ? req.body.next
+            : "/welcome";
+
+    // forwards the fullscreen flag onto the redirect query string
+    // since fullscreen is not session-persisted and would otherwise
+    // be lost on the next request
+    const fullscreen = req.body.fullscreen === "1";
+    const params = new URLSearchParams();
+    if (fullscreen) params.set("fullscreen", "1");
+    const query = params.toString() ? "?" + params.toString() : "";
+
+    res.redirect(302, target + query);
+});
+
 app.get("/welcome", (req, res, next) => {
     const fullscreen = req.query.fullscreen === "1";
     const theme = req.query.theme || req.session.theme || "";
@@ -115,6 +173,7 @@ app.get("/welcome", (req, res, next) => {
         master: master,
         masterb64: masterb64,
         config: req.session.config || {},
+        showOptions: req.session.show_options !== "0",
         info: info || {}
     });
 });

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -12,6 +12,7 @@ const CSS_FILES = [
     "css/text.css",
     "css/viewport.css",
     "css/welcome.css",
+    "css/settings.css",
     "css/plugins/collapsible.css",
     "css/plugins/console.css",
     "css/plugins/inspiration.css",

--- a/static/css/bundle.css
+++ b/static/css/bundle.css
@@ -1468,6 +1468,7 @@ body.ldj .line {
 }
 
 .welcome .welcome-version {
+    background-color: #ffffff;
     color: #9aa0ad;
     flex: 0 0 auto;
     font-size: 9px;

--- a/static/css/bundle.css
+++ b/static/css/bundle.css
@@ -1163,12 +1163,12 @@ body.ldj .line {
 
 .welcome .welcome-hero {
     flex: 0 0 auto;
-    padding: 32px 48px 20px 48px;
+    padding: 12px 48px 12px 48px;
     text-align: center;
 }
 
 .welcome .welcome-hero > .welcome-hero-mark {
-    margin-bottom: 12px;
+    margin: 12px auto 12px auto;
 }
 
 .welcome .welcome-hero > .welcome-hero-mark > .logo {
@@ -1370,13 +1370,13 @@ body.ldj .line {
     text-transform: uppercase;
 }
 
-.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips {
+.welcome .option-chips {
     display: inline-flex;
     flex-wrap: wrap;
     gap: 6px;
 }
 
-.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip-input {
+.welcome .option-chips > .option-chip-input {
     height: 0px;
     margin: 0px 0px 0px 0px;
     opacity: 0;
@@ -1390,7 +1390,7 @@ body.ldj .line {
     width: 0px;
 }
 
-.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip {
+.welcome .option-chips > .option-chip {
     background-color: #f4f5f8;
     border: 1px solid #e6e8ee;
     border-radius: 999px 999px 999px 999px;
@@ -1416,12 +1416,12 @@ body.ldj .line {
     -webkit-transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
-.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip:hover {
+.welcome .option-chips > .option-chip:hover {
     border-color: #cfd4de;
     color: #1f2330;
 }
 
-.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip-input:checked + .option-chip {
+.welcome .option-chips > .option-chip-input:checked + .option-chip {
     background-color: #1f2330;
     border-color: #1f2330;
     color: #ffffff;
@@ -1529,18 +1529,18 @@ body.ldj .welcome .welcome-action-bar > .welcome-options > .option-group > .opti
     color: #9b87c2;
 }
 
-body.ldj .welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip {
+body.ldj .welcome .option-chips > .option-chip {
     background-color: #f5f0fa;
     border-color: #ece4f5;
     color: #6b5a8a;
 }
 
-body.ldj .welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip:hover {
+body.ldj .welcome .option-chips > .option-chip:hover {
     border-color: #c9b6e5;
     color: #1f1430;
 }
 
-body.ldj .welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip-input:checked + .option-chip {
+body.ldj .welcome .option-chips > .option-chip-input:checked + .option-chip {
     background-color: #9678d3;
     border-color: #9678d3;
     color: #ffffff;
@@ -1553,6 +1553,42 @@ body.ldj .welcome .welcome-action-bar > .welcome-actions > .button.button-ghost 
 
 body.ldj .welcome .welcome-action-bar > .welcome-actions > .button.button-ghost:hover {
     background-color: #f5f0fa;
+}
+
+.welcome > .form.form-settings > .welcome-catalog > .settings-container {
+    margin: 6px auto 12px auto;
+    max-height: 560px;
+    max-width: 480px;
+    padding: 8px 0px 8px 0px;
+}
+
+.welcome > .form.form-settings > .welcome-action-bar {
+    justify-content: center;
+}
+
+.welcome > .form.form-settings > .welcome-action-bar > .welcome-options {
+    display: none;
+}
+
+.welcome > .form.form-settings > .welcome-catalog > .settings-container > .settings-group {
+    margin: 0px 0px 24px 0px;
+}
+
+.welcome > .form.form-settings > .welcome-catalog > .settings-container > .settings-group:last-child {
+    margin-bottom: 0px;
+}
+
+.welcome > .form.form-settings > .welcome-catalog > .settings-container > .settings-group > .settings-group-label {
+    color: #6b7280;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 1px;
+    margin-bottom: 8px;
+    text-transform: uppercase;
+}
+
+body.ldj .welcome > .form.form-settings > .welcome-catalog > .settings-container > .settings-group > .settings-group-label {
+    color: #9b87c2;
 }
 
 .collapsible > .collapsible-title {

--- a/static/css/bundle.css
+++ b/static/css/bundle.css
@@ -1348,6 +1348,10 @@ body.ldj .line {
     padding: 16px 48px 16px 48px;
 }
 
+.welcome .welcome-action-bar.centered {
+    justify-content: center;
+}
+
 .welcome .welcome-action-bar > .welcome-options {
     display: flex;
     flex: 1;

--- a/static/css/settings.css
+++ b/static/css/settings.css
@@ -1,0 +1,35 @@
+.welcome > .form.form-settings > .welcome-catalog > .settings-container {
+    margin: 6px auto 12px auto;
+    max-height: 560px;
+    max-width: 480px;
+    padding: 8px 0px 8px 0px;
+}
+
+.welcome > .form.form-settings > .welcome-action-bar {
+    justify-content: center;
+}
+
+.welcome > .form.form-settings > .welcome-action-bar > .welcome-options {
+    display: none;
+}
+
+.welcome > .form.form-settings > .welcome-catalog > .settings-container > .settings-group {
+    margin: 0px 0px 24px 0px;
+}
+
+.welcome > .form.form-settings > .welcome-catalog > .settings-container > .settings-group:last-child {
+    margin-bottom: 0px;
+}
+
+.welcome > .form.form-settings > .welcome-catalog > .settings-container > .settings-group > .settings-group-label {
+    color: #6b7280;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 1px;
+    margin-bottom: 8px;
+    text-transform: uppercase;
+}
+
+body.ldj .welcome > .form.form-settings > .welcome-catalog > .settings-container > .settings-group > .settings-group-label {
+    color: #9b87c2;
+}

--- a/static/css/welcome.css
+++ b/static/css/welcome.css
@@ -40,12 +40,12 @@
 
 .welcome .welcome-hero {
     flex: 0 0 auto;
-    padding: 32px 48px 20px 48px;
+    padding: 12px 48px 12px 48px;
     text-align: center;
 }
 
 .welcome .welcome-hero > .welcome-hero-mark {
-    margin-bottom: 12px;
+    margin: 12px auto 12px auto;
 }
 
 .welcome .welcome-hero > .welcome-hero-mark > .logo {
@@ -247,13 +247,13 @@
     text-transform: uppercase;
 }
 
-.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips {
+.welcome .option-chips {
     display: inline-flex;
     flex-wrap: wrap;
     gap: 6px;
 }
 
-.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip-input {
+.welcome .option-chips > .option-chip-input {
     height: 0px;
     margin: 0px 0px 0px 0px;
     opacity: 0;
@@ -267,7 +267,7 @@
     width: 0px;
 }
 
-.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip {
+.welcome .option-chips > .option-chip {
     background-color: #f4f5f8;
     border: 1px solid #e6e8ee;
     border-radius: 999px 999px 999px 999px;
@@ -293,12 +293,12 @@
     -webkit-transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
-.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip:hover {
+.welcome .option-chips > .option-chip:hover {
     border-color: #cfd4de;
     color: #1f2330;
 }
 
-.welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip-input:checked + .option-chip {
+.welcome .option-chips > .option-chip-input:checked + .option-chip {
     background-color: #1f2330;
     border-color: #1f2330;
     color: #ffffff;
@@ -406,18 +406,18 @@ body.ldj .welcome .welcome-action-bar > .welcome-options > .option-group > .opti
     color: #9b87c2;
 }
 
-body.ldj .welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip {
+body.ldj .welcome .option-chips > .option-chip {
     background-color: #f5f0fa;
     border-color: #ece4f5;
     color: #6b5a8a;
 }
 
-body.ldj .welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip:hover {
+body.ldj .welcome .option-chips > .option-chip:hover {
     border-color: #c9b6e5;
     color: #1f1430;
 }
 
-body.ldj .welcome .welcome-action-bar > .welcome-options > .option-group > .option-chips > .option-chip-input:checked + .option-chip {
+body.ldj .welcome .option-chips > .option-chip-input:checked + .option-chip {
     background-color: #9678d3;
     border-color: #9678d3;
     color: #ffffff;

--- a/static/css/welcome.css
+++ b/static/css/welcome.css
@@ -225,6 +225,10 @@
     padding: 16px 48px 16px 48px;
 }
 
+.welcome .welcome-action-bar.centered {
+    justify-content: center;
+}
+
 .welcome .welcome-action-bar > .welcome-options {
     display: flex;
     flex: 1;

--- a/static/css/welcome.css
+++ b/static/css/welcome.css
@@ -345,6 +345,7 @@
 }
 
 .welcome .welcome-version {
+    background-color: #ffffff;
     color: #9aa0ad;
     flex: 0 0 auto;
     font-size: 9px;

--- a/views/gateway-pt_pt.ejs
+++ b/views/gateway-pt_pt.ejs
@@ -39,51 +39,57 @@
                                value="<%= config.observations ? config.observations : '' %>" />
                     </div>
                 </div>
-                <div class="field">
-                    <label class="name">Tecnologia</label>
-                    <div class="value" id="technology">
-                        <input class="radio" type="radio" id="diamond" name="technology" value="diamond"
-                            <%= config.technology === "diamond" ? "checked" : '' %>>
-                        <label class="radio-label" for="diamond">Diamante</label>
-                        <input class="radio" type="radio" id="laser" name="technology" value="laser"
-                            <%= config.technology === "laser" ? "checked" : '' %>>
-                        <label class="radio-label" for="laser">Laser</label>
-                        <input class="radio" type="radio" id="fresa" name="technology" value="fresa"
-                            <%= config.technology === "fresa" ? "checked" : '' %>>
-                        <label class="radio-label" for="fresa">Fresa</label>
-                        <input class="radio" type="radio" id="pantograph" name="technology" value="pantograph"
-                            <%= config.technology === "pantograph" ? "checked" : '' %>>
-                        <label class="radio-label" for="pantograph">Pantógrafo</label>
+                <% if (showOptions) { %>
+                    <div class="field">
+                        <label class="name">Tecnologia</label>
+                        <div class="value" id="technology">
+                            <input class="radio" type="radio" id="diamond" name="technology" value="diamond"
+                                <%= config.technology === "diamond" ? "checked" : '' %>>
+                            <label class="radio-label" for="diamond">Diamante</label>
+                            <input class="radio" type="radio" id="laser" name="technology" value="laser"
+                                <%= config.technology === "laser" ? "checked" : '' %>>
+                            <label class="radio-label" for="laser">Laser</label>
+                            <input class="radio" type="radio" id="fresa" name="technology" value="fresa"
+                                <%= config.technology === "fresa" ? "checked" : '' %>>
+                            <label class="radio-label" for="fresa">Fresa</label>
+                            <input class="radio" type="radio" id="pantograph" name="technology" value="pantograph"
+                                <%= config.technology === "pantograph" ? "checked" : '' %>>
+                            <label class="radio-label" for="pantograph">Pantógrafo</label>
+                        </div>
                     </div>
-                </div>
-                <div class="field">
-                    <label class="name">Elementos</label>
-                    <div class="value" id="elements">
-                        <input class="radio" type="radio" id="text" name="elements" value="text"
-                            <%= config.elements === "text" ? "checked" : '' %>>
-                        <label class="radio-label" for="text">Texto</label>
-                        <input class="radio" type="radio" id="calligraphy" name="elements" value="calligraphy"
-                            <%= config.elements === "calligraphy" ? "checked" : '' %>>
-                        <label class="radio-label" for="calligraphy">Caligrafia</label>
-                        <input class="radio" type="radio" id="digital-printing" name="elements" value="digital_printing"
-                            <%= config.elements === "digital_printing" ? "checked" : '' %>>
-                        <label class="radio-label" for="digital-printing">Impr. digital</label>
-                        <input class="radio" type="radio" id="graphic-element" name="elements" value="graphic_element"
-                            <%= config.elements === "graphic_element" ? "checked" : '' %>>
-                        <label class="radio-label" for="graphic-element">Elemento gráfico</label>
+                    <div class="field">
+                        <label class="name">Elementos</label>
+                        <div class="value" id="elements">
+                            <input class="radio" type="radio" id="text" name="elements" value="text"
+                                <%= config.elements === "text" ? "checked" : '' %>>
+                            <label class="radio-label" for="text">Texto</label>
+                            <input class="radio" type="radio" id="calligraphy" name="elements" value="calligraphy"
+                                <%= config.elements === "calligraphy" ? "checked" : '' %>>
+                            <label class="radio-label" for="calligraphy">Caligrafia</label>
+                            <input class="radio" type="radio" id="digital-printing" name="elements" value="digital_printing"
+                                <%= config.elements === "digital_printing" ? "checked" : '' %>>
+                            <label class="radio-label" for="digital-printing">Impr. digital</label>
+                            <input class="radio" type="radio" id="graphic-element" name="elements" value="graphic_element"
+                                <%= config.elements === "graphic_element" ? "checked" : '' %>>
+                            <label class="radio-label" for="graphic-element">Elemento gráfico</label>
+                        </div>
                     </div>
-                </div>
-                <div class="field">
-                    <label class="name">Localização</label>
-                    <div class="value" id="location">
-                        <input class="radio" type="radio" id="interior" name="location" value="interior"
-                            <%= config.location === "interior" ? "checked" : '' %>>
-                        <label class="radio-label" for="interior">Interior</label>
-                        <input class="radio" type="radio" id="exterior" name="location" value="exterior"
-                            <%= config.location === "exterior" ? "checked" : '' %>>
-                        <label class="radio-label" for="exterior">Exterior</label>
+                    <div class="field">
+                        <label class="name">Localização</label>
+                        <div class="value" id="location">
+                            <input class="radio" type="radio" id="interior" name="location" value="interior"
+                                <%= config.location === "interior" ? "checked" : '' %>>
+                            <label class="radio-label" for="interior">Interior</label>
+                            <input class="radio" type="radio" id="exterior" name="location" value="exterior"
+                                <%= config.location === "exterior" ? "checked" : '' %>>
+                            <label class="radio-label" for="exterior">Exterior</label>
+                        </div>
                     </div>
-                </div>
+                <% } else { %>
+                    <input type="hidden" name="technology" value="<%= config.technology ? config.technology : 'diamond' %>" />
+                    <input type="hidden" name="elements" value="<%= config.elements ? config.elements : 'text' %>" />
+                    <input type="hidden" name="location" value="<%= config.location ? config.location : 'interior' %>" />
+                <% } %>
                 <div class="buttons-container">
                     <button type="submit" class="button">Submeter</span>
                 </div>

--- a/views/gateway.ejs
+++ b/views/gateway.ejs
@@ -39,51 +39,57 @@
                                value="<%= config.observations ? config.observations : '' %>" />
                     </div>
                 </div>
-                <div class="field">
-                    <label class="name">Technology</label>
-                    <div class="value" id="technology">
-                        <input class="radio" type="radio" id="diamond" name="technology" value="diamond"
-                            <%= !config.technology || config.technology === "diamond" ? "checked" : '' %>>
-                        <label class="radio-label" for="diamond">Diamond</label>
-                        <input class="radio" type="radio" id="laser" name="technology" value="laser"
-                            <%= config.technology === "laser" ? "checked" : '' %>>
-                        <label class="radio-label" for="laser">Laser</label>
-                        <input class="radio" type="radio" id="fresa" name="technology" value="fresa"
-                            <%= config.technology === "fresa" ? "checked" : '' %>>
-                        <label class="radio-label" for="fresa">Fresa</label>
-                        <input class="radio" type="radio" id="pantograph" name="technology" value="pantograph"
-                        <%= config.technology === "pantograph" ? "checked" : '' %>>
-                    <label class="radio-label" for="pantograph">Pantograph</label>
+                <% if (showOptions) { %>
+                    <div class="field">
+                        <label class="name">Technology</label>
+                        <div class="value" id="technology">
+                            <input class="radio" type="radio" id="diamond" name="technology" value="diamond"
+                                <%= !config.technology || config.technology === "diamond" ? "checked" : '' %>>
+                            <label class="radio-label" for="diamond">Diamond</label>
+                            <input class="radio" type="radio" id="laser" name="technology" value="laser"
+                                <%= config.technology === "laser" ? "checked" : '' %>>
+                            <label class="radio-label" for="laser">Laser</label>
+                            <input class="radio" type="radio" id="fresa" name="technology" value="fresa"
+                                <%= config.technology === "fresa" ? "checked" : '' %>>
+                            <label class="radio-label" for="fresa">Fresa</label>
+                            <input class="radio" type="radio" id="pantograph" name="technology" value="pantograph"
+                            <%= config.technology === "pantograph" ? "checked" : '' %>>
+                        <label class="radio-label" for="pantograph">Pantograph</label>
+                        </div>
                     </div>
-                </div>
-                <div class="field">
-                    <label class="name">Elements</label>
-                    <div class="value" id="elements">
-                        <input class="radio" type="radio" id="text" name="elements" value="text"
-                            <%= !config.elements || config.elements === "text" ? "checked" : '' %>>
-                        <label class="radio-label" for="text">Text</label>
-                        <input class="radio" type="radio" id="calligraphy" name="elements" value="calligraphy"
-                            <%= config.elements === "calligraphy" ? "checked" : '' %>>
-                        <label class="radio-label" for="calligraphy">Calligraphy</label>
-                        <input class="radio" type="radio" id="digital-printing" name="elements" value="digital_printing"
-                            <%= config.elements === "digital_printing" ? "checked" : '' %>>
-                        <label class="radio-label" for="digital-printing">Dig. print</label>
-                        <input class="radio" type="radio" id="graphic-element" name="elements" value="graphic_element"
-                            <%= config.elements === "graphic_element" ? "checked" : '' %>>
-                        <label class="radio-label" for="graphic-element">Graphic element</label>
+                    <div class="field">
+                        <label class="name">Elements</label>
+                        <div class="value" id="elements">
+                            <input class="radio" type="radio" id="text" name="elements" value="text"
+                                <%= !config.elements || config.elements === "text" ? "checked" : '' %>>
+                            <label class="radio-label" for="text">Text</label>
+                            <input class="radio" type="radio" id="calligraphy" name="elements" value="calligraphy"
+                                <%= config.elements === "calligraphy" ? "checked" : '' %>>
+                            <label class="radio-label" for="calligraphy">Calligraphy</label>
+                            <input class="radio" type="radio" id="digital-printing" name="elements" value="digital_printing"
+                                <%= config.elements === "digital_printing" ? "checked" : '' %>>
+                            <label class="radio-label" for="digital-printing">Dig. print</label>
+                            <input class="radio" type="radio" id="graphic-element" name="elements" value="graphic_element"
+                                <%= config.elements === "graphic_element" ? "checked" : '' %>>
+                            <label class="radio-label" for="graphic-element">Graphic element</label>
+                        </div>
                     </div>
-                </div>
-                <div class="field">
-                    <label class="name">Location</label>
-                    <div class="value" id="location">
-                        <input class="radio" type="radio" id="interior" name="location" value="interior"
-                            <%= !config.location || config.location === "interior" ? "checked" : '' %>>
-                        <label class="radio-label" for="interior">Interior</label>
-                        <input class="radio" type="radio" id="exterior" name="location" value="exterior"
-                            <%= config.location === "exterior" ? "checked" : '' %>>
-                        <label class="radio-label" for="exterior">Exterior</label>
+                    <div class="field">
+                        <label class="name">Location</label>
+                        <div class="value" id="location">
+                            <input class="radio" type="radio" id="interior" name="location" value="interior"
+                                <%= !config.location || config.location === "interior" ? "checked" : '' %>>
+                            <label class="radio-label" for="interior">Interior</label>
+                            <input class="radio" type="radio" id="exterior" name="location" value="exterior"
+                                <%= config.location === "exterior" ? "checked" : '' %>>
+                            <label class="radio-label" for="exterior">Exterior</label>
+                        </div>
                     </div>
-                </div>
+                <% } else { %>
+                    <input type="hidden" name="technology" value="<%= config.technology ? config.technology : 'diamond' %>" />
+                    <input type="hidden" name="elements" value="<%= config.elements ? config.elements : 'text' %>" />
+                    <input type="hidden" name="location" value="<%= config.location ? config.location : 'interior' %>" />
+                <% } %>
                 <input type="hidden" name="entry" value="gateway" />
                 <div class="buttons-container">
                     <button type="submit" class="button">Submit</button>

--- a/views/head.ejs
+++ b/views/head.ejs
@@ -18,6 +18,7 @@
         <link rel="stylesheet" type="text/css" href="/static/css/text.css">
         <link rel="stylesheet" type="text/css" href="/static/css/viewport.css">
         <link rel="stylesheet" type="text/css" href="/static/css/welcome.css">
+        <link rel="stylesheet" type="text/css" href="/static/css/settings.css">
         <link rel="stylesheet" type="text/css" href="/static/css/plugins/collapsible.css">
         <link rel="stylesheet" type="text/css" href="/static/css/plugins/console.css">
         <link rel="stylesheet" type="text/css" href="/static/css/plugins/inspiration.css">

--- a/views/settings-pt_pt.ejs
+++ b/views/settings-pt_pt.ejs
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="pt">
+    <%- include("head"); -%>
+    <body class="<%= theme %>" data-theme="<%= theme %>">
+        <div class="welcome">
+            <form class="form form-settings" method="post" action="/settings">
+                <div class="welcome-hero">
+                    <div class="welcome-hero-mark">
+                        <% if (theme === "ldj") { %>
+                            <img class="logo" src="/static/images/logo.svg" />
+                        <% } else { %>
+                            <span class="logo">Signatur</span>
+                        <% } %>
+                    </div>
+                    <div class="welcome-hero-eyebrow">Definições</div>
+                    <div class="welcome-hero-divider"></div>
+                </div>
+                <div class="welcome-catalog">
+                    <div class="settings-container">
+                        <div class="settings-group">
+                            <div class="settings-group-label">Tema</div>
+                            <div class="option-chips" id="theme-options">
+                                <input class="option-chip-input" type="radio" id="theme-default" name="theme" value=""
+                                    <%= !theme ? "checked" : '' %>>
+                                <label class="option-chip" for="theme-default">Predefinido</label>
+                                <input class="option-chip-input" type="radio" id="theme-ldj" name="theme" value="ldj"
+                                    <%= theme === "ldj" ? "checked" : '' %>>
+                                <label class="option-chip" for="theme-ldj">Lugar da Joia</label>
+                            </div>
+                        </div>
+                        <div class="settings-group">
+                            <div class="settings-group-label">Idioma</div>
+                            <div class="option-chips" id="locale-options">
+                                <input class="option-chip-input" type="radio" id="locale-default" name="locale" value=""
+                                    <%= !locale ? "checked" : '' %>>
+                                <label class="option-chip" for="locale-default">English</label>
+                                <input class="option-chip-input" type="radio" id="locale-pt-pt" name="locale" value="pt_pt"
+                                    <%= locale === "pt_pt" ? "checked" : '' %>>
+                                <label class="option-chip" for="locale-pt-pt">Português</label>
+                            </div>
+                        </div>
+                        <div class="settings-group">
+                            <div class="settings-group-label">Ecrã Inteiro</div>
+                            <div class="option-chips" id="fullscreen-options">
+                                <input class="option-chip-input" type="radio" id="fullscreen-off" name="fullscreen" value="0"
+                                    <%= !fullscreen ? "checked" : '' %>>
+                                <label class="option-chip" for="fullscreen-off">Desligado</label>
+                                <input class="option-chip-input" type="radio" id="fullscreen-on" name="fullscreen" value="1"
+                                    <%= fullscreen ? "checked" : '' %>>
+                                <label class="option-chip" for="fullscreen-on">Ligado</label>
+                            </div>
+                        </div>
+                        <div class="settings-group">
+                            <div class="settings-group-label">Página Inicial</div>
+                            <div class="option-chips" id="home-options">
+                                <input class="option-chip-input" type="radio" id="home-gateway" name="home" value="gateway"
+                                    <%= home !== "welcome" ? "checked" : '' %>>
+                                <label class="option-chip" for="home-gateway">Entrada</label>
+                                <input class="option-chip-input" type="radio" id="home-welcome" name="home" value="welcome"
+                                    <%= home === "welcome" ? "checked" : '' %>>
+                                <label class="option-chip" for="home-welcome">Boas-vindas</label>
+                            </div>
+                        </div>
+                        <div class="settings-group">
+                            <div class="settings-group-label">Mostrar Opções</div>
+                            <div class="option-chips" id="show-options">
+                                <input class="option-chip-input" type="radio" id="show-options-on" name="show_options" value="1"
+                                    <%= showOptions ? "checked" : '' %>>
+                                <label class="option-chip" for="show-options-on">Ligado</label>
+                                <input class="option-chip-input" type="radio" id="show-options-off" name="show_options" value="0"
+                                    <%= !showOptions ? "checked" : '' %>>
+                                <label class="option-chip" for="show-options-off">Desligado</label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <input type="hidden" name="next" value="<%= next ? next : '' %>" />
+                <div class="welcome-action-bar">
+                    <div class="welcome-options"></div>
+                    <div class="welcome-actions">
+                        <a class="button button-ghost button-cancel" href="<%= next ? next : '/welcome' %>">Cancelar</a>
+                        <button type="submit" class="button button-start">Guardar</button>
+                    </div>
+                </div>
+                <div class="welcome-version">
+                    <span>Versão <%= info.version %></span>
+                </div>
+            </form>
+        </div>
+    </body>
+</html>

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+    <%- include("head"); -%>
+    <body class="<%= theme %>" data-theme="<%= theme %>">
+        <div class="welcome">
+            <form class="form form-settings" method="post" action="/settings">
+                <div class="welcome-hero">
+                    <div class="welcome-hero-mark">
+                        <% if (theme === "ldj") { %>
+                            <img class="logo" src="/static/images/logo.svg" />
+                        <% } else { %>
+                            <span class="logo">Signatur</span>
+                        <% } %>
+                    </div>
+                    <div class="welcome-hero-eyebrow">Settings</div>
+                    <div class="welcome-hero-divider"></div>
+                </div>
+                <div class="welcome-catalog">
+                    <div class="settings-container">
+                        <div class="settings-group">
+                            <div class="settings-group-label">Theme</div>
+                            <div class="option-chips" id="theme-options">
+                                <input class="option-chip-input" type="radio" id="theme-default" name="theme" value=""
+                                    <%= !theme ? "checked" : '' %>>
+                                <label class="option-chip" for="theme-default">Default</label>
+                                <input class="option-chip-input" type="radio" id="theme-ldj" name="theme" value="ldj"
+                                    <%= theme === "ldj" ? "checked" : '' %>>
+                                <label class="option-chip" for="theme-ldj">Lugar da Joia</label>
+                            </div>
+                        </div>
+                        <div class="settings-group">
+                            <div class="settings-group-label">Locale</div>
+                            <div class="option-chips" id="locale-options">
+                                <input class="option-chip-input" type="radio" id="locale-default" name="locale" value=""
+                                    <%= !locale ? "checked" : '' %>>
+                                <label class="option-chip" for="locale-default">English</label>
+                                <input class="option-chip-input" type="radio" id="locale-pt-pt" name="locale" value="pt_pt"
+                                    <%= locale === "pt_pt" ? "checked" : '' %>>
+                                <label class="option-chip" for="locale-pt-pt">Português</label>
+                            </div>
+                        </div>
+                        <div class="settings-group">
+                            <div class="settings-group-label">Fullscreen</div>
+                            <div class="option-chips" id="fullscreen-options">
+                                <input class="option-chip-input" type="radio" id="fullscreen-off" name="fullscreen" value="0"
+                                    <%= !fullscreen ? "checked" : '' %>>
+                                <label class="option-chip" for="fullscreen-off">Off</label>
+                                <input class="option-chip-input" type="radio" id="fullscreen-on" name="fullscreen" value="1"
+                                    <%= fullscreen ? "checked" : '' %>>
+                                <label class="option-chip" for="fullscreen-on">On</label>
+                            </div>
+                        </div>
+                        <div class="settings-group">
+                            <div class="settings-group-label">Default Home</div>
+                            <div class="option-chips" id="home-options">
+                                <input class="option-chip-input" type="radio" id="home-gateway" name="home" value="gateway"
+                                    <%= home !== "welcome" ? "checked" : '' %>>
+                                <label class="option-chip" for="home-gateway">Gateway</label>
+                                <input class="option-chip-input" type="radio" id="home-welcome" name="home" value="welcome"
+                                    <%= home === "welcome" ? "checked" : '' %>>
+                                <label class="option-chip" for="home-welcome">Welcome</label>
+                            </div>
+                        </div>
+                        <div class="settings-group">
+                            <div class="settings-group-label">Show Options</div>
+                            <div class="option-chips" id="show-options">
+                                <input class="option-chip-input" type="radio" id="show-options-on" name="show_options" value="1"
+                                    <%= showOptions ? "checked" : '' %>>
+                                <label class="option-chip" for="show-options-on">On</label>
+                                <input class="option-chip-input" type="radio" id="show-options-off" name="show_options" value="0"
+                                    <%= !showOptions ? "checked" : '' %>>
+                                <label class="option-chip" for="show-options-off">Off</label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <input type="hidden" name="next" value="<%= next ? next : '' %>" />
+                <div class="welcome-action-bar">
+                    <div class="welcome-options"></div>
+                    <div class="welcome-actions">
+                        <a class="button button-ghost button-cancel" href="<%= next ? next : '/welcome' %>">Cancel</a>
+                        <button type="submit" class="button button-start">Save</button>
+                    </div>
+                </div>
+                <div class="welcome-version">
+                    <span>Version <%= info.version %></span>
+                </div>
+            </form>
+        </div>
+    </body>
+</html>

--- a/views/welcome-pt_pt.ejs
+++ b/views/welcome-pt_pt.ejs
@@ -23,7 +23,7 @@
                 <input class="profile-input" type="hidden" name="profile" value="<%= config.profile ? config.profile : '' %>" />
                 <input class="variant-input" type="hidden" name="variant" value="<%= config.variant ? config.variant : '' %>" />
                 <input type="hidden" name="entry" value="welcome" />
-                <div class="welcome-action-bar">
+                <div class="welcome-action-bar<%= showOptions ? '' : ' centered' %>">
                     <% if (showOptions) { %>
                         <div class="welcome-options">
                             <div class="option-group">

--- a/views/welcome-pt_pt.ejs
+++ b/views/welcome-pt_pt.ejs
@@ -24,54 +24,61 @@
                 <input class="variant-input" type="hidden" name="variant" value="<%= config.variant ? config.variant : '' %>" />
                 <input type="hidden" name="entry" value="welcome" />
                 <div class="welcome-action-bar">
-                    <div class="welcome-options">
-                        <div class="option-group">
-                            <span class="option-group-label">Tecnologia</span>
-                            <div class="option-chips" id="technology">
-                                <input class="option-chip-input" type="radio" id="diamond" name="technology" value="diamond"
-                                    <%= !config.technology || config.technology === "diamond" ? "checked" : '' %>>
-                                <label class="option-chip" for="diamond">Diamante</label>
-                                <input class="option-chip-input" type="radio" id="laser" name="technology" value="laser"
-                                    <%= config.technology === "laser" ? "checked" : '' %>>
-                                <label class="option-chip" for="laser">Laser</label>
-                                <input class="option-chip-input" type="radio" id="fresa" name="technology" value="fresa"
-                                    <%= config.technology === "fresa" ? "checked" : '' %>>
-                                <label class="option-chip" for="fresa">Fresa</label>
-                                <input class="option-chip-input" type="radio" id="pantograph" name="technology" value="pantograph"
-                                    <%= config.technology === "pantograph" ? "checked" : '' %>>
-                                <label class="option-chip" for="pantograph">Pantógrafo</label>
+                    <% if (showOptions) { %>
+                        <div class="welcome-options">
+                            <div class="option-group">
+                                <span class="option-group-label">Tecnologia</span>
+                                <div class="option-chips" id="technology">
+                                    <input class="option-chip-input" type="radio" id="diamond" name="technology" value="diamond"
+                                        <%= !config.technology || config.technology === "diamond" ? "checked" : '' %>>
+                                    <label class="option-chip" for="diamond">Diamante</label>
+                                    <input class="option-chip-input" type="radio" id="laser" name="technology" value="laser"
+                                        <%= config.technology === "laser" ? "checked" : '' %>>
+                                    <label class="option-chip" for="laser">Laser</label>
+                                    <input class="option-chip-input" type="radio" id="fresa" name="technology" value="fresa"
+                                        <%= config.technology === "fresa" ? "checked" : '' %>>
+                                    <label class="option-chip" for="fresa">Fresa</label>
+                                    <input class="option-chip-input" type="radio" id="pantograph" name="technology" value="pantograph"
+                                        <%= config.technology === "pantograph" ? "checked" : '' %>>
+                                    <label class="option-chip" for="pantograph">Pantógrafo</label>
+                                </div>
+                            </div>
+                            <div class="option-group">
+                                <span class="option-group-label">Elementos</span>
+                                <div class="option-chips" id="elements">
+                                    <input class="option-chip-input" type="radio" id="text" name="elements" value="text"
+                                        <%= !config.elements || config.elements === "text" ? "checked" : '' %>>
+                                    <label class="option-chip" for="text">Texto</label>
+                                    <input class="option-chip-input" type="radio" id="calligraphy" name="elements" value="calligraphy"
+                                        <%= config.elements === "calligraphy" ? "checked" : '' %>>
+                                    <label class="option-chip" for="calligraphy">Caligrafia</label>
+                                    <input class="option-chip-input" type="radio" id="digital-printing" name="elements" value="digital_printing"
+                                        <%= config.elements === "digital_printing" ? "checked" : '' %>>
+                                    <label class="option-chip" for="digital-printing">Impr. digital</label>
+                                    <input class="option-chip-input" type="radio" id="graphic-element" name="elements" value="graphic_element"
+                                        <%= config.elements === "graphic_element" ? "checked" : '' %>>
+                                    <label class="option-chip" for="graphic-element">Gráfico</label>
+                                </div>
+                            </div>
+                            <div class="option-group">
+                                <span class="option-group-label">Localização</span>
+                                <div class="option-chips" id="location">
+                                    <input class="option-chip-input" type="radio" id="interior" name="location" value="interior"
+                                        <%= !config.location || config.location === "interior" ? "checked" : '' %>>
+                                    <label class="option-chip" for="interior">Interior</label>
+                                    <input class="option-chip-input" type="radio" id="exterior" name="location" value="exterior"
+                                        <%= config.location === "exterior" ? "checked" : '' %>>
+                                    <label class="option-chip" for="exterior">Exterior</label>
+                                </div>
                             </div>
                         </div>
-                        <div class="option-group">
-                            <span class="option-group-label">Elementos</span>
-                            <div class="option-chips" id="elements">
-                                <input class="option-chip-input" type="radio" id="text" name="elements" value="text"
-                                    <%= !config.elements || config.elements === "text" ? "checked" : '' %>>
-                                <label class="option-chip" for="text">Texto</label>
-                                <input class="option-chip-input" type="radio" id="calligraphy" name="elements" value="calligraphy"
-                                    <%= config.elements === "calligraphy" ? "checked" : '' %>>
-                                <label class="option-chip" for="calligraphy">Caligrafia</label>
-                                <input class="option-chip-input" type="radio" id="digital-printing" name="elements" value="digital_printing"
-                                    <%= config.elements === "digital_printing" ? "checked" : '' %>>
-                                <label class="option-chip" for="digital-printing">Impr. digital</label>
-                                <input class="option-chip-input" type="radio" id="graphic-element" name="elements" value="graphic_element"
-                                    <%= config.elements === "graphic_element" ? "checked" : '' %>>
-                                <label class="option-chip" for="graphic-element">Gráfico</label>
-                            </div>
-                        </div>
-                        <div class="option-group">
-                            <span class="option-group-label">Localização</span>
-                            <div class="option-chips" id="location">
-                                <input class="option-chip-input" type="radio" id="interior" name="location" value="interior"
-                                    <%= !config.location || config.location === "interior" ? "checked" : '' %>>
-                                <label class="option-chip" for="interior">Interior</label>
-                                <input class="option-chip-input" type="radio" id="exterior" name="location" value="exterior"
-                                    <%= config.location === "exterior" ? "checked" : '' %>>
-                                <label class="option-chip" for="exterior">Exterior</label>
-                            </div>
-                        </div>
-                    </div>
+                    <% } else { %>
+                        <input type="hidden" name="technology" value="<%= config.technology ? config.technology : 'diamond' %>" />
+                        <input type="hidden" name="elements" value="<%= config.elements ? config.elements : 'text' %>" />
+                        <input type="hidden" name="location" value="<%= config.location ? config.location : 'interior' %>" />
+                    <% } %>
                     <div class="welcome-actions">
+                        <a class="button button-ghost button-settings" href="/settings?next=/welcome">Definições</a>
                         <a class="button button-ghost button-classic" href="/gateway">Clássico</a>
                         <button type="submit" class="button button-start" disabled>Iniciar</button>
                     </div>

--- a/views/welcome.ejs
+++ b/views/welcome.ejs
@@ -23,7 +23,7 @@
                 <input class="profile-input" type="hidden" name="profile" value="<%= config.profile ? config.profile : '' %>" />
                 <input class="variant-input" type="hidden" name="variant" value="<%= config.variant ? config.variant : '' %>" />
                 <input type="hidden" name="entry" value="welcome" />
-                <div class="welcome-action-bar">
+                <div class="welcome-action-bar<%= showOptions ? '' : ' centered' %>">
                     <% if (showOptions) { %>
                         <div class="welcome-options">
                             <div class="option-group">

--- a/views/welcome.ejs
+++ b/views/welcome.ejs
@@ -24,54 +24,61 @@
                 <input class="variant-input" type="hidden" name="variant" value="<%= config.variant ? config.variant : '' %>" />
                 <input type="hidden" name="entry" value="welcome" />
                 <div class="welcome-action-bar">
-                    <div class="welcome-options">
-                        <div class="option-group">
-                            <span class="option-group-label">Technology</span>
-                            <div class="option-chips" id="technology">
-                                <input class="option-chip-input" type="radio" id="diamond" name="technology" value="diamond"
-                                    <%= !config.technology || config.technology === "diamond" ? "checked" : '' %>>
-                                <label class="option-chip" for="diamond">Diamond</label>
-                                <input class="option-chip-input" type="radio" id="laser" name="technology" value="laser"
-                                    <%= config.technology === "laser" ? "checked" : '' %>>
-                                <label class="option-chip" for="laser">Laser</label>
-                                <input class="option-chip-input" type="radio" id="fresa" name="technology" value="fresa"
-                                    <%= config.technology === "fresa" ? "checked" : '' %>>
-                                <label class="option-chip" for="fresa">Fresa</label>
-                                <input class="option-chip-input" type="radio" id="pantograph" name="technology" value="pantograph"
-                                    <%= config.technology === "pantograph" ? "checked" : '' %>>
-                                <label class="option-chip" for="pantograph">Pantograph</label>
+                    <% if (showOptions) { %>
+                        <div class="welcome-options">
+                            <div class="option-group">
+                                <span class="option-group-label">Technology</span>
+                                <div class="option-chips" id="technology">
+                                    <input class="option-chip-input" type="radio" id="diamond" name="technology" value="diamond"
+                                        <%= !config.technology || config.technology === "diamond" ? "checked" : '' %>>
+                                    <label class="option-chip" for="diamond">Diamond</label>
+                                    <input class="option-chip-input" type="radio" id="laser" name="technology" value="laser"
+                                        <%= config.technology === "laser" ? "checked" : '' %>>
+                                    <label class="option-chip" for="laser">Laser</label>
+                                    <input class="option-chip-input" type="radio" id="fresa" name="technology" value="fresa"
+                                        <%= config.technology === "fresa" ? "checked" : '' %>>
+                                    <label class="option-chip" for="fresa">Fresa</label>
+                                    <input class="option-chip-input" type="radio" id="pantograph" name="technology" value="pantograph"
+                                        <%= config.technology === "pantograph" ? "checked" : '' %>>
+                                    <label class="option-chip" for="pantograph">Pantograph</label>
+                                </div>
+                            </div>
+                            <div class="option-group">
+                                <span class="option-group-label">Elements</span>
+                                <div class="option-chips" id="elements">
+                                    <input class="option-chip-input" type="radio" id="text" name="elements" value="text"
+                                        <%= !config.elements || config.elements === "text" ? "checked" : '' %>>
+                                    <label class="option-chip" for="text">Text</label>
+                                    <input class="option-chip-input" type="radio" id="calligraphy" name="elements" value="calligraphy"
+                                        <%= config.elements === "calligraphy" ? "checked" : '' %>>
+                                    <label class="option-chip" for="calligraphy">Calligraphy</label>
+                                    <input class="option-chip-input" type="radio" id="digital-printing" name="elements" value="digital_printing"
+                                        <%= config.elements === "digital_printing" ? "checked" : '' %>>
+                                    <label class="option-chip" for="digital-printing">Dig. print</label>
+                                    <input class="option-chip-input" type="radio" id="graphic-element" name="elements" value="graphic_element"
+                                        <%= config.elements === "graphic_element" ? "checked" : '' %>>
+                                    <label class="option-chip" for="graphic-element">Graphic</label>
+                                </div>
+                            </div>
+                            <div class="option-group">
+                                <span class="option-group-label">Location</span>
+                                <div class="option-chips" id="location">
+                                    <input class="option-chip-input" type="radio" id="interior" name="location" value="interior"
+                                        <%= !config.location || config.location === "interior" ? "checked" : '' %>>
+                                    <label class="option-chip" for="interior">Interior</label>
+                                    <input class="option-chip-input" type="radio" id="exterior" name="location" value="exterior"
+                                        <%= config.location === "exterior" ? "checked" : '' %>>
+                                    <label class="option-chip" for="exterior">Exterior</label>
+                                </div>
                             </div>
                         </div>
-                        <div class="option-group">
-                            <span class="option-group-label">Elements</span>
-                            <div class="option-chips" id="elements">
-                                <input class="option-chip-input" type="radio" id="text" name="elements" value="text"
-                                    <%= !config.elements || config.elements === "text" ? "checked" : '' %>>
-                                <label class="option-chip" for="text">Text</label>
-                                <input class="option-chip-input" type="radio" id="calligraphy" name="elements" value="calligraphy"
-                                    <%= config.elements === "calligraphy" ? "checked" : '' %>>
-                                <label class="option-chip" for="calligraphy">Calligraphy</label>
-                                <input class="option-chip-input" type="radio" id="digital-printing" name="elements" value="digital_printing"
-                                    <%= config.elements === "digital_printing" ? "checked" : '' %>>
-                                <label class="option-chip" for="digital-printing">Dig. print</label>
-                                <input class="option-chip-input" type="radio" id="graphic-element" name="elements" value="graphic_element"
-                                    <%= config.elements === "graphic_element" ? "checked" : '' %>>
-                                <label class="option-chip" for="graphic-element">Graphic</label>
-                            </div>
-                        </div>
-                        <div class="option-group">
-                            <span class="option-group-label">Location</span>
-                            <div class="option-chips" id="location">
-                                <input class="option-chip-input" type="radio" id="interior" name="location" value="interior"
-                                    <%= !config.location || config.location === "interior" ? "checked" : '' %>>
-                                <label class="option-chip" for="interior">Interior</label>
-                                <input class="option-chip-input" type="radio" id="exterior" name="location" value="exterior"
-                                    <%= config.location === "exterior" ? "checked" : '' %>>
-                                <label class="option-chip" for="exterior">Exterior</label>
-                            </div>
-                        </div>
-                    </div>
+                    <% } else { %>
+                        <input type="hidden" name="technology" value="<%= config.technology ? config.technology : 'diamond' %>" />
+                        <input type="hidden" name="elements" value="<%= config.elements ? config.elements : 'text' %>" />
+                        <input type="hidden" name="location" value="<%= config.location ? config.location : 'interior' %>" />
+                    <% } %>
                     <div class="welcome-actions">
+                        <a class="button button-ghost button-settings" href="/settings?next=/welcome">Settings</a>
                         <a class="button button-ghost button-classic" href="/gateway">Classic</a>
                         <button type="submit" class="button button-start" disabled>Start</button>
                     </div>


### PR DESCRIPTION
## Summary

- Add a new **Query Parameters** section to `README.md` grouping the supported query parameters per route, with a per-route support matrix for `theme` / `locale` / `fullscreen` and tables for the text payload, template pre-selection, viewport editor state, and `/convert` parameters.
- Document the `format` query parameter accepted by the inkscape engine on the `/convert` endpoint, with the supported values (`svg`, `pdf`, `hpgl`).
- Reword the `PRINT_URL` / `PRINT_NODE` / `PRINT_PRINTER` / `PRINT_KEY` descriptions in the existing Configuration table so it is clear these values are consumed when printing the **report receipt**, not as generic Colony Print configuration.
- Drop the legacy Travis CI build badge from the Build Automation section, leaving the GitHub Actions workflow badge as the single source of build status.
- Apply a white background to the welcome screen version footer so it visually matches the action bar above it instead of bleeding into the page surface (carry-over polish from #22 that didn't make it into the squashed merge).
- Update `CHANGELOG.md` under the `[Unreleased]` section.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` rebuilds bundles cleanly
- [x] `npm test` passes
- [x] README renders cleanly on GitHub with the new Query Parameters section
- [x] Visit `/welcome` and confirm the version footer now sits flush on a white surface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for supported HTTP query parameters, grouped by route with types, defaults, and descriptions.
  * Expanded configuration reference with PRINT_* environment variables (URL, Node, Printer, Key).
  * Updated CI/CD badge from Travis CI to GitHub Actions.

* **Style**
  * Updated welcome screen footer to display with white background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->