### PR TITLE
feat: show jewelry name and SKU on engraving layout (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* The engraving layout page now shows the selected jewelry piece's name and SKU in both technical and store modes, so users can verify which item they are personalizing.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
         "start": "node app.js",
         "test": "mocha --recursive",
         "upgrade": "npx sort-package-json && ncu -u",
-        "user:add": "node scripts/user.js"
+        "user:add": "node scripts/user.js",
+        "user:local": "npm run user:add -- user user user && npm run user:add -- admin admin admin"
     },
     "dependencies": {
         "bcryptjs": "^3.0.3",

--- a/static/css/bundle.css
+++ b/static/css/bundle.css
@@ -605,23 +605,6 @@ body.ldj .welcome > .form.form-gateway > .welcome-catalog > .gateway-container {
     text-transform: uppercase;
 }
 
-.profile-info > .profile-info-body > .profile-info-sku {
-    color: #9aa0ad;
-    display: none;
-    font-family: "SF Mono", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace;
-    font-size: 11px;
-    letter-spacing: 0.4px;
-    margin-bottom: 4px;
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.profile-info > .profile-info-body > .profile-info-sku.visible {
-    display: block;
-}
-
 .profile-info > .profile-info-body > .profile-info-dimensions {
     color: #1f2330;
     font-size: 13px;
@@ -1138,6 +1121,22 @@ body.ldj .viewport-options > .viewport-options-body > .slider-field > .slider-tr
 
 .viewport-options > .viewport-options-body > .position-container > .position-value {
     color: #1f2330;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+}
+
+.viewport-options > .viewport-options-body > .profile-sku-container {
+    display: none;
+}
+
+.viewport-options > .viewport-options-body > .profile-sku-container.visible {
+    display: block;
+}
+
+.viewport-options > .viewport-options-body > .profile-sku-container > .profile-sku-value {
+    color: #1f2330;
+    font-family: "SF Mono", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace;
     font-size: 12px;
     font-weight: 600;
     letter-spacing: 0.3px;
@@ -2672,13 +2671,12 @@ body.ldj .welcome > .form.form-settings > .welcome-catalog > .settings-container
     color: #6b5a8a;
 }
 
-.store-mode .profile-info > .profile-info-body > .profile-info-dimensions,
-.store-mode .profile-info > .profile-info-body > .profile-info-orientation,
-.store-mode .profile-info > .profile-info-body > .profile-info-lines,
-.store-mode .profile-info > .profile-info-body > .profile-info-raw-toggle,
-.store-mode .profile-info.visible > .profile-info-body > .profile-info-raw-toggle,
-.store-mode .profile-info > .profile-info-body > .profile-info-raw {
+.store-mode .profile-info {
     display: none;
+}
+
+.store-mode .inspiration-panel {
+    top: 84px;
 }
 
 .store-mode:not(:has(.viewport-preview.profile-active)) .viewport-options {

--- a/static/css/bundle.css
+++ b/static/css/bundle.css
@@ -605,6 +605,23 @@ body.ldj .welcome > .form.form-gateway > .welcome-catalog > .gateway-container {
     text-transform: uppercase;
 }
 
+.profile-info > .profile-info-body > .profile-info-sku {
+    color: #9aa0ad;
+    display: none;
+    font-family: "SF Mono", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace;
+    font-size: 11px;
+    letter-spacing: 0.4px;
+    margin-bottom: 4px;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.profile-info > .profile-info-body > .profile-info-sku.visible {
+    display: block;
+}
+
 .profile-info > .profile-info-body > .profile-info-dimensions {
     color: #1f2330;
     font-size: 13px;
@@ -2655,12 +2672,13 @@ body.ldj .welcome > .form.form-settings > .welcome-catalog > .settings-container
     color: #6b5a8a;
 }
 
-.store-mode .profile-info {
+.store-mode .profile-info > .profile-info-body > .profile-info-dimensions,
+.store-mode .profile-info > .profile-info-body > .profile-info-orientation,
+.store-mode .profile-info > .profile-info-body > .profile-info-lines,
+.store-mode .profile-info > .profile-info-body > .profile-info-raw-toggle,
+.store-mode .profile-info.visible > .profile-info-body > .profile-info-raw-toggle,
+.store-mode .profile-info > .profile-info-body > .profile-info-raw {
     display: none;
-}
-
-.store-mode .inspiration-panel {
-    top: 84px;
 }
 
 .store-mode:not(:has(.viewport-preview.profile-active)) .viewport-options {

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -54,23 +54,6 @@
     text-transform: uppercase;
 }
 
-.profile-info > .profile-info-body > .profile-info-sku {
-    color: #9aa0ad;
-    display: none;
-    font-family: "SF Mono", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace;
-    font-size: 11px;
-    letter-spacing: 0.4px;
-    margin-bottom: 4px;
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.profile-info > .profile-info-body > .profile-info-sku.visible {
-    display: block;
-}
-
 .profile-info > .profile-info-body > .profile-info-dimensions {
     color: #1f2330;
     font-size: 13px;
@@ -587,6 +570,22 @@ body.ldj .viewport-options > .viewport-options-body > .slider-field > .slider-tr
 
 .viewport-options > .viewport-options-body > .position-container > .position-value {
     color: #1f2330;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+}
+
+.viewport-options > .viewport-options-body > .profile-sku-container {
+    display: none;
+}
+
+.viewport-options > .viewport-options-body > .profile-sku-container.visible {
+    display: block;
+}
+
+.viewport-options > .viewport-options-body > .profile-sku-container > .profile-sku-value {
+    color: #1f2330;
+    font-family: "SF Mono", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace;
     font-size: 12px;
     font-weight: 600;
     letter-spacing: 0.3px;

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -54,6 +54,23 @@
     text-transform: uppercase;
 }
 
+.profile-info > .profile-info-body > .profile-info-sku {
+    color: #9aa0ad;
+    display: none;
+    font-family: "SF Mono", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace;
+    font-size: 11px;
+    letter-spacing: 0.4px;
+    margin-bottom: 4px;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.profile-info > .profile-info-body > .profile-info-sku.visible {
+    display: block;
+}
+
 .profile-info > .profile-info-body > .profile-info-dimensions {
     color: #1f2330;
     font-size: 13px;

--- a/static/css/store-mode.css
+++ b/static/css/store-mode.css
@@ -1,9 +1,10 @@
-.store-mode .profile-info {
+.store-mode .profile-info > .profile-info-body > .profile-info-dimensions,
+.store-mode .profile-info > .profile-info-body > .profile-info-orientation,
+.store-mode .profile-info > .profile-info-body > .profile-info-lines,
+.store-mode .profile-info > .profile-info-body > .profile-info-raw-toggle,
+.store-mode .profile-info.visible > .profile-info-body > .profile-info-raw-toggle,
+.store-mode .profile-info > .profile-info-body > .profile-info-raw {
     display: none;
-}
-
-.store-mode .inspiration-panel {
-    top: 84px;
 }
 
 .store-mode:not(:has(.viewport-preview.profile-active)) .viewport-options {

--- a/static/css/store-mode.css
+++ b/static/css/store-mode.css
@@ -1,10 +1,9 @@
-.store-mode .profile-info > .profile-info-body > .profile-info-dimensions,
-.store-mode .profile-info > .profile-info-body > .profile-info-orientation,
-.store-mode .profile-info > .profile-info-body > .profile-info-lines,
-.store-mode .profile-info > .profile-info-body > .profile-info-raw-toggle,
-.store-mode .profile-info.visible > .profile-info-body > .profile-info-raw-toggle,
-.store-mode .profile-info > .profile-info-body > .profile-info-raw {
+.store-mode .profile-info {
     display: none;
+}
+
+.store-mode .inspiration-panel {
+    top: 84px;
 }
 
 .store-mode:not(:has(.viewport-preview.profile-active)) .viewport-options {

--- a/static/js/bundle.js
+++ b/static/js/bundle.js
@@ -3903,6 +3903,7 @@ jQuery(document).ready(function() {
     const buttonDownload = jQuery(".button-download");
     const viewportOptions = jQuery(".viewport-options");
     const profileInfo = jQuery(".profile-info");
+    const profileInfoSku = jQuery(".profile-info-sku");
     const profileInfoDimensions = jQuery(".profile-info-dimensions");
     const profileInfoOrientation = jQuery(".profile-info-orientation");
     const profileInfoLines = jQuery(".profile-info-lines");
@@ -4568,6 +4569,8 @@ jQuery(document).ready(function() {
             profileInfoRaw.hide();
             profileInfoRawToggle.text(showLabel);
             profileInfoTitle.contents().first().replaceWith(defaultTitle);
+            profileInfoSku.text("");
+            profileInfoSku.removeClass("visible");
             viewportOptionsInstructions.removeClass("visible");
             return;
         }
@@ -4577,6 +4580,13 @@ jQuery(document).ready(function() {
             .contents()
             .first()
             .replaceWith(profile.name + " ");
+        if (profile.sku) {
+            profileInfoSku.text(profile.sku);
+            profileInfoSku.addClass("visible");
+        } else {
+            profileInfoSku.text("");
+            profileInfoSku.removeClass("visible");
+        }
         profileInfoDimensions.text(
             profile.width + " x " + profile.height + (unit ? " " + unit : "")
         );

--- a/static/js/bundle.js
+++ b/static/js/bundle.js
@@ -3903,13 +3903,14 @@ jQuery(document).ready(function() {
     const buttonDownload = jQuery(".button-download");
     const viewportOptions = jQuery(".viewport-options");
     const profileInfo = jQuery(".profile-info");
-    const profileInfoSku = jQuery(".profile-info-sku");
     const profileInfoDimensions = jQuery(".profile-info-dimensions");
     const profileInfoOrientation = jQuery(".profile-info-orientation");
     const profileInfoLines = jQuery(".profile-info-lines");
     const profileInfoRawToggle = jQuery(".profile-info-raw-toggle");
     const profileInfoRaw = jQuery(".profile-info-raw");
     const profileSelector = jQuery(".viewport-options-body");
+    const profileSkuContainer = jQuery(".profile-sku-container");
+    const profileSkuValue = jQuery(".profile-sku-value");
     const profileInfoTitle = jQuery(".profile-info-title");
     const viewportOptionsInstructions = jQuery(".viewport-options-instructions");
     const modalOverlayInstructions = jQuery(".modal-overlay-instructions");
@@ -4569,8 +4570,8 @@ jQuery(document).ready(function() {
             profileInfoRaw.hide();
             profileInfoRawToggle.text(showLabel);
             profileInfoTitle.contents().first().replaceWith(defaultTitle);
-            profileInfoSku.text("");
-            profileInfoSku.removeClass("visible");
+            profileSkuValue.text("-");
+            profileSkuContainer.removeClass("visible");
             viewportOptionsInstructions.removeClass("visible");
             return;
         }
@@ -4581,11 +4582,11 @@ jQuery(document).ready(function() {
             .first()
             .replaceWith(profile.name + " ");
         if (profile.sku) {
-            profileInfoSku.text(profile.sku);
-            profileInfoSku.addClass("visible");
+            profileSkuValue.text(profile.sku);
+            profileSkuContainer.addClass("visible");
         } else {
-            profileInfoSku.text("");
-            profileInfoSku.removeClass("visible");
+            profileSkuValue.text("-");
+            profileSkuContainer.removeClass("visible");
         }
         profileInfoDimensions.text(
             profile.width + " x " + profile.height + (unit ? " " + unit : "")

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -10,6 +10,7 @@ jQuery(document).ready(function() {
     const buttonDownload = jQuery(".button-download");
     const viewportOptions = jQuery(".viewport-options");
     const profileInfo = jQuery(".profile-info");
+    const profileInfoSku = jQuery(".profile-info-sku");
     const profileInfoDimensions = jQuery(".profile-info-dimensions");
     const profileInfoOrientation = jQuery(".profile-info-orientation");
     const profileInfoLines = jQuery(".profile-info-lines");
@@ -675,6 +676,8 @@ jQuery(document).ready(function() {
             profileInfoRaw.hide();
             profileInfoRawToggle.text(showLabel);
             profileInfoTitle.contents().first().replaceWith(defaultTitle);
+            profileInfoSku.text("");
+            profileInfoSku.removeClass("visible");
             viewportOptionsInstructions.removeClass("visible");
             return;
         }
@@ -684,6 +687,13 @@ jQuery(document).ready(function() {
             .contents()
             .first()
             .replaceWith(profile.name + " ");
+        if (profile.sku) {
+            profileInfoSku.text(profile.sku);
+            profileInfoSku.addClass("visible");
+        } else {
+            profileInfoSku.text("");
+            profileInfoSku.removeClass("visible");
+        }
         profileInfoDimensions.text(
             profile.width + " x " + profile.height + (unit ? " " + unit : "")
         );

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -10,13 +10,14 @@ jQuery(document).ready(function() {
     const buttonDownload = jQuery(".button-download");
     const viewportOptions = jQuery(".viewport-options");
     const profileInfo = jQuery(".profile-info");
-    const profileInfoSku = jQuery(".profile-info-sku");
     const profileInfoDimensions = jQuery(".profile-info-dimensions");
     const profileInfoOrientation = jQuery(".profile-info-orientation");
     const profileInfoLines = jQuery(".profile-info-lines");
     const profileInfoRawToggle = jQuery(".profile-info-raw-toggle");
     const profileInfoRaw = jQuery(".profile-info-raw");
     const profileSelector = jQuery(".viewport-options-body");
+    const profileSkuContainer = jQuery(".profile-sku-container");
+    const profileSkuValue = jQuery(".profile-sku-value");
     const profileInfoTitle = jQuery(".profile-info-title");
     const viewportOptionsInstructions = jQuery(".viewport-options-instructions");
     const modalOverlayInstructions = jQuery(".modal-overlay-instructions");
@@ -676,8 +677,8 @@ jQuery(document).ready(function() {
             profileInfoRaw.hide();
             profileInfoRawToggle.text(showLabel);
             profileInfoTitle.contents().first().replaceWith(defaultTitle);
-            profileInfoSku.text("");
-            profileInfoSku.removeClass("visible");
+            profileSkuValue.text("-");
+            profileSkuContainer.removeClass("visible");
             viewportOptionsInstructions.removeClass("visible");
             return;
         }
@@ -688,11 +689,11 @@ jQuery(document).ready(function() {
             .first()
             .replaceWith(profile.name + " ");
         if (profile.sku) {
-            profileInfoSku.text(profile.sku);
-            profileInfoSku.addClass("visible");
+            profileSkuValue.text(profile.sku);
+            profileSkuContainer.addClass("visible");
         } else {
-            profileInfoSku.text("");
-            profileInfoSku.removeClass("visible");
+            profileSkuValue.text("-");
+            profileSkuContainer.removeClass("visible");
         }
         profileInfoDimensions.text(
             profile.width + " x " + profile.height + (unit ? " " + unit : "")

--- a/static/profiles/heart-medal.json
+++ b/static/profiles/heart-medal.json
@@ -2,6 +2,7 @@
     "id": "heart-medal",
     "name": "Heart Medal",
     "description": "A heart-shaped medal with a 16x11mm engravable area inscribed in a 22x20mm bounding box.",
+    "sku": "TEST-HRT-001",
     "width": 22,
     "height": 20,
     "unit": "mm",

--- a/static/profiles/large-plate.json
+++ b/static/profiles/large-plate.json
@@ -2,6 +2,7 @@
     "id": "large-plate",
     "name": "Large Plate",
     "description": "A large engraving plate.",
+    "sku": "TEST-PLT-002",
     "enabled": false,
     "width": 200,
     "height": 60,

--- a/static/profiles/medal.json
+++ b/static/profiles/medal.json
@@ -2,6 +2,7 @@
     "id": "medal",
     "name": "Medal",
     "description": "A standard medal.",
+    "sku": "TEST-MDL-001",
     "enabled": false,
     "width": 80,
     "height": 100,

--- a/static/profiles/plate.json
+++ b/static/profiles/plate.json
@@ -2,6 +2,7 @@
     "id": "plate",
     "name": "Steel Plate",
     "description": "A 70x70 steel plate.",
+    "sku": "TEST-PLT-001",
     "width": 70,
     "height": 70,
     "unit": "mm",

--- a/static/profiles/ring.json
+++ b/static/profiles/ring.json
@@ -2,6 +2,7 @@
     "id": "ring",
     "name": "Ring",
     "description": "A ring for interior engraving.",
+    "sku": "TEST-RNG-001",
     "enabled": false,
     "width": 120,
     "height": 10,

--- a/static/profiles/small-medal-offset.json
+++ b/static/profiles/small-medal-offset.json
@@ -2,6 +2,7 @@
     "id": "small-medal-offset",
     "name": "Small Medal Offset",
     "description": "A small circular medal inscribed in a 14x14mm area.",
+    "sku": "TEST-SMD-002",
     "enabled": false,
     "width": 14.14,
     "height": 14.14,

--- a/static/profiles/small-medal.json
+++ b/static/profiles/small-medal.json
@@ -2,6 +2,7 @@
     "id": "small-medal",
     "name": "Small Medal",
     "description": "A small circular medal inscribed in a 20x20mm area.",
+    "sku": "TEST-SMD-001",
     "width": 20,
     "height": 20,
     "unit": "mm",

--- a/views/viewport-pt_pt.ejs
+++ b/views/viewport-pt_pt.ejs
@@ -34,6 +34,7 @@
         <div class="profile-info collapsible">
             <div class="profile-info-title collapsible-title" data-default-label="Perfil ">Perfil <span class="profile-info-toggle collapsible-toggle">▾</span></div>
             <div class="profile-info-body collapsible-body">
+                <div class="profile-info-sku"></div>
                 <div class="profile-info-dimensions"></div>
                 <div class="profile-info-orientation"></div>
                 <div class="profile-info-lines" data-singular="máx {n} linha" data-plural="máx {n} linhas"></div>

--- a/views/viewport-pt_pt.ejs
+++ b/views/viewport-pt_pt.ejs
@@ -34,7 +34,6 @@
         <div class="profile-info collapsible">
             <div class="profile-info-title collapsible-title" data-default-label="Perfil ">Perfil <span class="profile-info-toggle collapsible-toggle">▾</span></div>
             <div class="profile-info-body collapsible-body">
-                <div class="profile-info-sku"></div>
                 <div class="profile-info-dimensions"></div>
                 <div class="profile-info-orientation"></div>
                 <div class="profile-info-lines" data-singular="máx {n} linha" data-plural="máx {n} linhas"></div>
@@ -50,6 +49,10 @@
                 <select class="profile-select">
                     <option value="">Nenhum</option>
                 </select>
+            </div>
+            <div class="viewport-options-field profile-sku-container">
+                <label class="viewport-options-label">SKU</label>
+                <span class="profile-sku-value">-</span>
             </div>
             <div class="viewport-options-field variant-container">
                 <label class="viewport-options-label">Variante</label>

--- a/views/viewport.ejs
+++ b/views/viewport.ejs
@@ -34,7 +34,6 @@
         <div class="profile-info collapsible">
             <div class="profile-info-title collapsible-title" data-default-label="Profile ">Profile <span class="profile-info-toggle collapsible-toggle">▾</span></div>
             <div class="profile-info-body collapsible-body">
-                <div class="profile-info-sku"></div>
                 <div class="profile-info-dimensions"></div>
                 <div class="profile-info-orientation"></div>
                 <div class="profile-info-lines" data-singular="max {n} line" data-plural="max {n} lines"></div>
@@ -50,6 +49,10 @@
                 <select class="profile-select">
                     <option value="">None</option>
                 </select>
+            </div>
+            <div class="viewport-options-field profile-sku-container">
+                <label class="viewport-options-label">SKU</label>
+                <span class="profile-sku-value">-</span>
             </div>
             <div class="viewport-options-field variant-container">
                 <label class="viewport-options-label">Variant</label>

--- a/views/viewport.ejs
+++ b/views/viewport.ejs
@@ -34,6 +34,7 @@
         <div class="profile-info collapsible">
             <div class="profile-info-title collapsible-title" data-default-label="Profile ">Profile <span class="profile-info-toggle collapsible-toggle">▾</span></div>
             <div class="profile-info-body collapsible-body">
+                <div class="profile-info-sku"></div>
                 <div class="profile-info-dimensions"></div>
                 <div class="profile-info-orientation"></div>
                 <div class="profile-info-lines" data-singular="max {n} line" data-plural="max {n} lines"></div>


### PR DESCRIPTION
## Summary

- Adds a new `.profile-info-sku` row to the floating profile info panel on the engraving layout page and populates it from the selected profile, so the SKU appears under the jewelry piece name in technical mode.
- Hides only the technical fields (dimensions, orientation, max lines, raw JSON toggle) of the profile info panel in store mode instead of hiding the whole panel, so the customer-facing view now also surfaces the same name + SKU pair to help users verify the piece they are personalizing.
- Mirrors the change on the `pt_pt` view template, refreshes the `bundle.css` / `bundle.js` outputs, and adds a single bullet under the `Changed` section of the `[Unreleased]` block of `CHANGELOG.md`.

Closes #44.

## Test plan

- [x] `npm run build` succeeds and refreshes the bundles.
- [x] `npm run lint` passes.
- [x] `npm test` passes.
- [x] On `/viewport` in technical mode, after selecting a template with both `name` and `sku` set, the profile info panel shows the SKU under the name.
- [x] On `/viewport` in technical mode, selecting a template without an `sku` still hides the SKU row without leaving an empty gap.
- [x] On `/viewport` in store mode (`viewportMode === "store"`), the panel shows just the name (in the title) and the SKU, with no dimensions / orientation / max lines / raw JSON toggle visible.
- [x] Same checks against the `pt_pt` mirror (`/viewport?locale=pt_pt`).