### PR TITLE
fix: render the accent long-press popup above clipping containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Accent picker for top row keyboard keys no longer appears hidden behind other elements when long pressing
 
 ## [1.2.0] - 2026-06-09
 

--- a/static/css/bundle.css
+++ b/static/css/bundle.css
@@ -4678,7 +4678,7 @@ body.ldj .viewport > .main-container > .keyboard-container:not(.lowercase) > .ch
     color: #4b3a7a;
 }
 
-.viewport > .main-container > .keyboard-container > .accent-popup {
+.accent-popup {
     background-color: #ffffff;
     border: none;
     border-radius: 14px 14px 14px 14px;
@@ -4697,17 +4697,17 @@ body.ldj .viewport > .main-container > .keyboard-container:not(.lowercase) > .ch
     gap: 4px;
     margin-top: -8px;
     padding: 6px 6px 6px 6px;
-    position: absolute;
+    position: fixed;
     transform: translate(-50%, -100%);
     -o-transform: translate(-50%, -100%);
     -ms-transform: translate(-50%, -100%);
     -moz-transform: translate(-50%, -100%);
     -khtml-transform: translate(-50%, -100%);
     -webkit-transform: translate(-50%, -100%);
-    z-index: 100;
+    z-index: 1000;
 }
 
-.viewport > .main-container > .keyboard-container > .accent-popup > .accent-option {
+.accent-popup > .accent-option {
     background-color: #fafbfd;
     border-radius: 10px 10px 10px 10px;
     -o-border-radius: 10px 10px 10px 10px;
@@ -4731,17 +4731,17 @@ body.ldj .viewport > .main-container > .keyboard-container:not(.lowercase) > .ch
     -webkit-transition: background-color 0.12s ease, color 0.12s ease;
 }
 
-.viewport > .main-container > .keyboard-container > .accent-popup > .accent-option:hover {
+.accent-popup > .accent-option:hover {
     background-color: rgba(24, 24, 24, 1.0);
     color: #ffffff;
 }
 
-body.ldj .viewport > .main-container > .keyboard-container > .accent-popup > .accent-option:hover {
+body.ldj .accent-popup > .accent-option:hover {
     background-color: #9678d3;
     color: #ffffff;
 }
 
-.viewport > .main-container > .keyboard-container > .accent-popup > .accent-popup-arrow {
+.accent-popup > .accent-popup-arrow {
     border-left: 7px solid transparent;
     border-right: 7px solid transparent;
     border-top: 7px solid #ffffff;

--- a/static/css/plugins/keyboard.css
+++ b/static/css/plugins/keyboard.css
@@ -244,7 +244,7 @@ body.ldj .viewport > .main-container > .keyboard-container:not(.lowercase) > .ch
     color: #4b3a7a;
 }
 
-.viewport > .main-container > .keyboard-container > .accent-popup {
+.accent-popup {
     background-color: #ffffff;
     border: none;
     border-radius: 14px 14px 14px 14px;
@@ -263,17 +263,17 @@ body.ldj .viewport > .main-container > .keyboard-container:not(.lowercase) > .ch
     gap: 4px;
     margin-top: -8px;
     padding: 6px 6px 6px 6px;
-    position: absolute;
+    position: fixed;
     transform: translate(-50%, -100%);
     -o-transform: translate(-50%, -100%);
     -ms-transform: translate(-50%, -100%);
     -moz-transform: translate(-50%, -100%);
     -khtml-transform: translate(-50%, -100%);
     -webkit-transform: translate(-50%, -100%);
-    z-index: 100;
+    z-index: 1000;
 }
 
-.viewport > .main-container > .keyboard-container > .accent-popup > .accent-option {
+.accent-popup > .accent-option {
     background-color: #fafbfd;
     border-radius: 10px 10px 10px 10px;
     -o-border-radius: 10px 10px 10px 10px;
@@ -297,17 +297,17 @@ body.ldj .viewport > .main-container > .keyboard-container:not(.lowercase) > .ch
     -webkit-transition: background-color 0.12s ease, color 0.12s ease;
 }
 
-.viewport > .main-container > .keyboard-container > .accent-popup > .accent-option:hover {
+.accent-popup > .accent-option:hover {
     background-color: rgba(24, 24, 24, 1.0);
     color: #ffffff;
 }
 
-body.ldj .viewport > .main-container > .keyboard-container > .accent-popup > .accent-option:hover {
+body.ldj .accent-popup > .accent-option:hover {
     background-color: #9678d3;
     color: #ffffff;
 }
 
-.viewport > .main-container > .keyboard-container > .accent-popup > .accent-popup-arrow {
+.accent-popup > .accent-popup-arrow {
     border-left: 7px solid transparent;
     border-right: 7px solid transparent;
     border-top: 7px solid #ffffff;

--- a/static/js/bundle.js
+++ b/static/js/bundle.js
@@ -1764,6 +1764,11 @@ const countLines = function(text) {
          * Shows the accent popup above the pressed key with
          * the available accented character variants.
          *
+         * The popup is appended to the document body (instead of the
+         * keyboard container) and positioned with fixed coordinates so
+         * it is never clipped by the container's overflow handling, which
+         * would otherwise hide it for keys on the top keyboard row.
+         *
          * @param {Element} context The keyboard container context.
          * @param {Element} element The key element that was long pressed.
          * @param {String} accents Comma-separated list of accented characters.
@@ -1793,13 +1798,14 @@ const countLines = function(text) {
 
             popup.append(arrow);
 
-            const offset = element.offset();
-            const containerOffset = context.offset();
-            const left = offset.left - containerOffset.left + element.outerWidth() / 2;
-            const top = offset.top - containerOffset.top;
+            // positions the popup using viewport coordinates and anchors it
+            // to the body so it escapes the keyboard container's clipping
+            const rect = element[0].getBoundingClientRect();
+            const left = rect.left + rect.width / 2;
+            const top = rect.top;
             popup.css({ left: left + "px", top: top + "px" });
 
-            context.append(popup);
+            body.append(popup);
 
             // dismisses the popup when clicking outside of it
             // by registering a one-time click handler on the document

--- a/static/js/plugins/keyboard.js
+++ b/static/js/plugins/keyboard.js
@@ -74,6 +74,11 @@
          * Shows the accent popup above the pressed key with
          * the available accented character variants.
          *
+         * The popup is appended to the document body (instead of the
+         * keyboard container) and positioned with fixed coordinates so
+         * it is never clipped by the container's overflow handling, which
+         * would otherwise hide it for keys on the top keyboard row.
+         *
          * @param {Element} context The keyboard container context.
          * @param {Element} element The key element that was long pressed.
          * @param {String} accents Comma-separated list of accented characters.
@@ -103,13 +108,14 @@
 
             popup.append(arrow);
 
-            const offset = element.offset();
-            const containerOffset = context.offset();
-            const left = offset.left - containerOffset.left + element.outerWidth() / 2;
-            const top = offset.top - containerOffset.top;
+            // positions the popup using viewport coordinates and anchors it
+            // to the body so it escapes the keyboard container's clipping
+            const rect = element[0].getBoundingClientRect();
+            const left = rect.left + rect.width / 2;
+            const top = rect.top;
             popup.css({ left: left + "px", top: top + "px" });
 
-            context.append(popup);
+            body.append(popup);
 
             // dismisses the popup when clicking outside of it
             // by registering a one-time click handler on the document


### PR DESCRIPTION
## Summary

Fixes the accent long-press picker being hidden / clipped when long-pressing a key on the **first (top) row** of the on-screen keyboard. The **O** key is a good example to reproduce it.

Closes #59.

## Root cause

The accent popup was a child of `.keyboard-container`, which carries `overflow: hidden` (used for the preview-mode collapse animation). The popup renders above the pressed key via `transform: translate(-50%, -100%)`, so for top-row keys it lands entirely above the container's top edge and gets clipped away. Lower rows worked because the popup stayed inside the container box. It is therefore primarily an overflow-clipping problem (compounded by the popup's stacking order).

## Fix

- Anchor the accent popup to the document `body` and position it from the key's viewport rect (`getBoundingClientRect`) instead of container-relative offsets, so it escapes the keyboard container's `overflow: hidden`.
- Switch the popup to `position: fixed` and raise its stacking order so it always paints above surrounding elements.
- Regenerated `bundle.css` / `bundle.js` via `node scripts/build.js`.

## Testing

- `npm test` — 144 passing.
- `eslint` on the changed JS — passes.
- Not visually verified in a running browser (the keyboard view requires an authenticated session/config that isn't available headlessly); the change is a standard overflow-escape fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hivesolutions/codesmith/signatur/pr/60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783940889&installation_id=139073056&pr_number=60&repository=hivesolutions%2Fsignatur&return_to=https%3A%2F%2Fgithub.com%2Fhivesolutions%2Fsignatur%2Fpull%2F60&signature=8ce179eec5e050544f5843562e10ef969319ec1c361091df201dd6a5656f8056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the accent picker appeared hidden behind other elements when long pressing top row keyboard keys. The accent picker now displays correctly with improved layering and visibility.

* **Documentation**
  * Updated release notes to document the accent picker visibility improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->