### PR TITLE
feat: drive the emoji keyboard layout from the uploadable mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Emoji keyboard layout, categories and order are now driven by the uploadable emoji mapping, with uncategorized emojis gathered on a dedicated "Other" tab
+* Download the current emoji mapping file from the settings Emojis tab
 
 ### Changed
 

--- a/app.js
+++ b/app.js
@@ -402,6 +402,11 @@ app.get("/settings/emojis/mapping", lib.requireAdmin, (req, res, next) => {
         try {
             buffer = await fs.readFile(mappingPath);
         } catch (err) {
+            // treats only the missing file as a 404 and rethrows every
+            // other error (permissions, transient IO) so the existing
+            // error middleware can surface and log it as a 500 instead
+            // of masking a real operational problem behind not found
+            if (err.code !== "ENOENT") throw err;
             res.status(404).json({ error: "mapping not found" });
             return;
         }

--- a/app.js
+++ b/app.js
@@ -391,6 +391,27 @@ app.post("/settings/emojis", lib.requireAdmin, emojisUpload, (req, res, next) =>
     clojure().catch(next);
 });
 
+app.get("/settings/emojis/mapping", lib.requireAdmin, (req, res, next) => {
+    async function clojure() {
+        // serves the current mapping body as an attachment so the
+        // operator can pull the active layout down, edit the category
+        // and order metadata and upload it back through the same tab
+        const fontsDirectory = path.join(__dirname, "static", "fonts");
+        const mappingPath = path.join(fontsDirectory, "coolemojis.mapping.json");
+        let buffer;
+        try {
+            buffer = await fs.readFile(mappingPath);
+        } catch (err) {
+            res.status(404).json({ error: "mapping not found" });
+            return;
+        }
+        res.setHeader("Content-Type", "application/json");
+        res.setHeader("Content-Disposition", "attachment; filename=\"coolemojis.mapping.json\"");
+        res.send(buffer);
+    }
+    clojure().catch(next);
+});
+
 app.get("/settings/emojis/f3s", lib.requireAdmin, (req, res, next) => {
     async function clojure() {
         const directoryPath = path.join(__dirname, "static", "fonts", "f3s", "emoji");

--- a/docs/proposals/emoji-keyboard-config.md
+++ b/docs/proposals/emoji-keyboard-config.md
@@ -36,7 +36,7 @@ Make the emoji keyboard layout — which emoji, in which category, in what order
 ## Decisions taken
 
 - **Source of layout**: extend the existing uploadable `coolemojis.mapping.json` (single source of truth, already uploaded alongside the font).
-- **Rendering**: generate the grid client side in `static/js/plugins/keyboard.js`, reusing the mapping JSON that `main.js` already fetches. This keeps template churn low and lets uploads take effect on the next viewport load without a server restart.
+- **Rendering**: generate the grid client side in `static/js/main.js`, reusing the mapping JSON it already fetches and then initialising the existing keyboard plugin over the generated markup. This keeps template churn low and lets uploads take effect on the next viewport load without a server restart.
 
 ## Mapping format (backward compatible)
 
@@ -86,7 +86,7 @@ This must be relaxed to accept either:
 
 Anything else stays an error, with the same `errors[]` shape the upload route already surfaces. Keep the existing comment style and the existing message phrasing.
 
-### 2. Client side grid generation (`static/js/plugins/keyboard.js`)
+### 2. Client side grid generation (`static/js/main.js`)
 
 - Add a helper that, given the fetched mapping object, normalises every entry to `{ value, name, category, order }`, assigning a sentinel catch-all category (for example `other`) to any entry that declares none.
 - Build the tab strip (`.emojis-tabs > .emojis-tab`) from the distinct categories, mirroring the existing markup and the `data-category` / `active` conventions, with the catch-all "Other" tab appended last and emitted only when at least one uncategorized entry exists.
@@ -101,7 +101,7 @@ Anything else stays an error, with the same `errors[]` shape the upload route al
 ### 4. Template cleanup (`views/viewport.ejs`, `views/viewport-pt_pt.ejs`)
 
 - Reduce the hardcoded emoji blocks to empty containers (the tabs and `.char` spans become generated). Keep the `.emojis-container` / `.emojisp-container` shells, their `data-active` defaults, and the surrounding structure.
-- The Pantograph keyboard (`.emojisp-container`) gets the same treatment, sourced from its own mapping file when one is uploaded.
+- The Pantograph keyboard (`.emojisp-container`) stays static in this iteration because there is no `coolemojisp.mapping.json` to drive it; it keeps its bundled markup until its own mapping file is introduced.
 
 ### 5. Settings copy (`views/settings.ejs`, `views/settings-pt_pt.ejs`)
 

--- a/docs/proposals/emoji-keyboard-config.md
+++ b/docs/proposals/emoji-keyboard-config.md
@@ -1,0 +1,129 @@
+# Proposal: Configurable emoji keyboard driven by the uploadable mapping file
+
+## Problem
+
+The emoji keyboard has a split brain. Uploads are dynamic, but the layout is static.
+
+What an admin can already change from **Settings → Emojis**:
+
+- The display font (`coolemojis.ttf`) via `POST /settings/emojis`.
+- The glyph → name mapping (`coolemojis.mapping.json`), used for the per key tooltips.
+- The engraving `.f3s` payloads, dropped into `static/fonts/f3s/emoji/`.
+
+What an admin cannot change without a developer editing templates:
+
+- Which emoji keys appear on the keyboard — the `.char` spans hardcoded in `views/viewport.ejs` (and the `-pt_pt` twin).
+- Which tab/category each emoji lands in — the `data-category` attribute, written by hand per key.
+- The order/position of each emoji in the grid — driven by DOM source order.
+- The tab list itself (Symbols, Nature, People, Pop, Phrases).
+
+The result: uploading a new emoji font replaces the glyphs but changes nothing on the keyboard. A new glyph only becomes reachable after a developer hand edits the markup, and the arbitrary `data-value` slot letters (`A`, `B`, `$`, `@` …) must stay in lockstep across three places with no single source of truth:
+
+1. the `.char` spans in the EJS views,
+2. the `coolemojis.mapping.json` entries,
+3. the glyph order baked into the font.
+
+This is the gap behind "we need more configuration for the emoji keyboard and where newly uploaded emojis go".
+
+## Goal
+
+Make the emoji keyboard layout — which emoji, in which category, in what order — a configuration concern owned by the already uploadable mapping file, so that:
+
+- Adding or reordering emojis, or moving one between tabs, is an admin upload, not a code change.
+- There is a single source of truth (the mapping file) for slot, glyph name, category and order.
+- The change is backward compatible with the current mapping files and the current behaviour.
+
+## Decisions taken
+
+- **Source of layout**: extend the existing uploadable `coolemojis.mapping.json` (single source of truth, already uploaded alongside the font).
+- **Rendering**: generate the grid client side in `static/js/plugins/keyboard.js`, reusing the mapping JSON that `main.js` already fetches. This keeps template churn low and lets uploads take effect on the next viewport load without a server restart.
+
+## Mapping format (backward compatible)
+
+Today every entry maps a slot character to a glyph name:
+
+```json
+{
+    "A": "1101.coracao",
+    "B": "1102.estrela"
+}
+```
+
+The extended form lets an entry also carry a category and an order, while the plain string form keeps working unchanged:
+
+```json
+{
+    "A": { "name": "1101.coracao", "category": "nature", "order": 10 },
+    "B": "1102.estrela"
+}
+```
+
+Rules:
+
+- A string value is treated as `{ name: <string> }` with no category and no order (current behaviour).
+- `category` is optional; entries without one are gathered into a dedicated catch-all tab (labelled "Other") instead of being folded into an existing category, so uncategorized uploads stay visible and reachable rather than disappearing into a real bucket. This also means an old all-string mapping file surfaces entirely under the "Other" tab, with nothing lost.
+- `order` is optional; entries without one keep their position from the file's key order, sorted after any entry that does declare an `order`.
+- The tab list is derived from the distinct categories present, in first seen order, so adding a category to the mapping adds a tab. The catch-all "Other" tab is appended last and only when at least one uncategorized entry exists.
+
+The display semantics stay the same: the slot character is the key value sent on press, and the glyph is rendered by the Cool Emojis font; `name` continues to drive the tooltip.
+
+## Work breakdown
+
+### 1. Server side mapping validation (`lib/util/emojis.js`)
+
+`validateEmojisMapping` currently rejects any non string value:
+
+```js
+if (typeof parsed[key] !== "string") {
+    errors.push(`mapping entry "${key}" must be a string`);
+}
+```
+
+This must be relaxed to accept either:
+
+- a string (the current form), or
+- an object with a required string `name`, an optional string `category`, and an optional numeric `order`.
+
+Anything else stays an error, with the same `errors[]` shape the upload route already surfaces. Keep the existing comment style and the existing message phrasing.
+
+### 2. Client side grid generation (`static/js/plugins/keyboard.js`)
+
+- Add a helper that, given the fetched mapping object, normalises every entry to `{ value, name, category, order }`, assigning a sentinel catch-all category (for example `other`) to any entry that declares none.
+- Build the tab strip (`.emojis-tabs > .emojis-tab`) from the distinct categories, mirroring the existing markup and the `data-category` / `active` conventions, with the catch-all "Other" tab appended last and emitted only when at least one uncategorized entry exists.
+- Build the `.char` spans with the same classes and `data-category` / `data-value` attributes the CSS already filters on (uncategorized entries carry `data-category="other"`), so `static/css/plugins/keyboard.css` needs only the catch-all category added to the existing `data-active` filter selector list.
+- Re-run the existing tab wiring and key wiring after generation (the plugin already binds these by class convention).
+
+### 3. Load and render integration (`static/js/main.js`)
+
+- `main.js` already fetches `coolemojis.mapping.json` and walks `.char[data-value]` to set tooltips. Have it pass the mapping to the keyboard plugin (or expose the normalised layout) so the grid is generated from the same fetch instead of from hardcoded markup.
+- Keep the tooltip behaviour (title from `name`) intact.
+
+### 4. Template cleanup (`views/viewport.ejs`, `views/viewport-pt_pt.ejs`)
+
+- Reduce the hardcoded emoji blocks to empty containers (the tabs and `.char` spans become generated). Keep the `.emojis-container` / `.emojisp-container` shells, their `data-active` defaults, and the surrounding structure.
+- The Pantograph keyboard (`.emojisp-container`) gets the same treatment, sourced from its own mapping file when one is uploaded.
+
+### 5. Settings copy (`views/settings.ejs`, `views/settings-pt_pt.ejs`)
+
+- Update the Emojis tab helper text to mention that the mapping file now also controls category and order, so admins know the upload drives the keyboard layout.
+
+### 6. Build, lint, tests, changelog
+
+- Rebuild bundles: `npm run build` (regenerates `bundle.js` / `bundle.css`).
+- `npm run lint` and `npm test` per the pre commit checklist.
+- Add unit tests for the relaxed `validateEmojisMapping` (string form, object form, missing `name`, bad `category`, bad `order`).
+- Add a single user facing line under `CHANGELOG.md` `[Unreleased] > Added`.
+- Preserve CRLF line endings in JS/CSS/EJS and the vendor prefix order.
+
+## Backward compatibility and risks
+
+- Existing `coolemojis.mapping.json` files (all string values) keep every key; with no categories declared they all surface under the catch-all "Other" tab, so nothing is lost (the within-tab order is preserved from the file).
+- The catch-all "Other" tab needs a sentinel category value (for example `other`) that is reserved and cannot collide with an admin-declared category name.
+- Client side generation means the grid depends on the mapping fetch succeeding; if the fetch fails the keyboard should degrade gracefully (empty emoji grid, regular keyboard unaffected) rather than break.
+- The Pantograph variant has its own glyph set; it needs its own mapping file to be configurable the same way, otherwise it keeps a built in default.
+
+## Out of scope
+
+- A visual editor for arranging emojis.
+- Per profile emoji subsets (today `config/master.json` only gates whether the emoji fonts appear at all).
+- Server side rendering of the grid (explicitly chosen to render client side).

--- a/lib/util/emojis.js
+++ b/lib/util/emojis.js
@@ -56,9 +56,11 @@ const validateEmojisFont = buffer => {
 
 /**
  * Validates that the provided JSON text parses into a flat
- * object of string to string entries matching the shape of
- * the bundled `coolemojis.mapping.json` so that the existing
- * viewport consumer keeps working after the upload.
+ * object whose entries are either the plain glyph name string
+ * matching the bundled `coolemojis.mapping.json` shape or the
+ * extended object form carrying an optional category and order
+ * so the viewport can lay the emoji keyboard out from the same
+ * mapping the upload replaces.
  *
  * @param {String} text The mapping payload to inspect.
  * @returns {Array} An array of error messages (empty if valid).
@@ -83,13 +85,27 @@ const validateEmojisMapping = text => {
         return errors;
     }
 
-    // walks every entry and rejects non string values upfront so
-    // a malformed mapping cannot land on disk and break the
-    // downstream viewport lookup that expects character to name
-    // pairs for every glyph in the emoji catalog
+    // walks every entry and accepts both the plain string form and
+    // the extended object form upfront so a malformed mapping cannot
+    // land on disk and break the downstream viewport lookup that
+    // expects a glyph name for every character in the emoji catalog
     for (const key of Object.keys(parsed)) {
-        if (typeof parsed[key] !== "string") {
-            errors.push(`mapping entry "${key}" must be a string`);
+        const value = parsed[key];
+        if (typeof value === "string") {
+            continue;
+        }
+        if (typeof value !== "object" || value === null || Array.isArray(value)) {
+            errors.push(`mapping entry "${key}" must be a string or an object`);
+            continue;
+        }
+        if (typeof value.name !== "string") {
+            errors.push(`mapping entry "${key}" must have a string "name"`);
+        }
+        if (value.category !== undefined && typeof value.category !== "string") {
+            errors.push(`mapping entry "${key}" must have a string "category"`);
+        }
+        if (value.order !== undefined && typeof value.order !== "number") {
+            errors.push(`mapping entry "${key}" must have a numeric "order"`);
         }
     }
 

--- a/lib/util/emojis.js
+++ b/lib/util/emojis.js
@@ -104,7 +104,7 @@ const validateEmojisMapping = text => {
         if (value.category !== undefined && typeof value.category !== "string") {
             errors.push(`mapping entry "${key}" must have a string "category"`);
         }
-        if (value.order !== undefined && typeof value.order !== "number") {
+        if (value.order !== undefined && !Number.isFinite(value.order)) {
             errors.push(`mapping entry "${key}" must have a numeric "order"`);
         }
     }

--- a/static/css/bundle.css
+++ b/static/css/bundle.css
@@ -3701,6 +3701,26 @@ body.ldj .welcome > .form.form-settings > .welcome-catalog > .settings-container
     margin: 0px 0px 16px 0px;
 }
 
+.welcome > .form.form-settings > .welcome-catalog > .settings-container > .settings-group > .emojis-actions > .button.button-ghost {
+    background-color: #f4f5f8;
+    border: none;
+    color: #4b5260;
+    text-align: center;
+}
+
+.welcome > .form.form-settings > .welcome-catalog > .settings-container > .settings-group > .emojis-actions > .button.button-ghost:hover {
+    background-color: #e7eaf0;
+}
+
+body.ldj .welcome > .form.form-settings > .welcome-catalog > .settings-container > .settings-group > .emojis-actions > .button.button-ghost {
+    border-color: #ece4f5;
+    color: #6b5a8a;
+}
+
+body.ldj .welcome > .form.form-settings > .welcome-catalog > .settings-container > .settings-group > .emojis-actions > .button.button-ghost:hover {
+    background-color: #f5f0fa;
+}
+
 .welcome > .form.form-settings > .welcome-catalog > .settings-container > .settings-group > .emojis-feedback {
     background-color: #f5f6f8;
     border-radius: 12px;
@@ -4577,10 +4597,12 @@ body.ldj .viewport > .main-container > .emojisp-container > .emojis-tabs > .emoj
 .viewport > .main-container > .emojis-container[data-active="people"] > .char[data-category]:not([data-category="people"]),
 .viewport > .main-container > .emojis-container[data-active="pop"] > .char[data-category]:not([data-category="pop"]),
 .viewport > .main-container > .emojis-container[data-active="phrases"] > .char[data-category]:not([data-category="phrases"]),
+.viewport > .main-container > .emojis-container[data-active="other"] > .char[data-category]:not([data-category="other"]),
 .viewport > .main-container > .emojisp-container[data-active="symbols"] > .char[data-category]:not([data-category="symbols"]),
 .viewport > .main-container > .emojisp-container[data-active="nature"] > .char[data-category]:not([data-category="nature"]),
 .viewport > .main-container > .emojisp-container[data-active="people"] > .char[data-category]:not([data-category="people"]),
-.viewport > .main-container > .emojisp-container[data-active="pop"] > .char[data-category]:not([data-category="pop"]) {
+.viewport > .main-container > .emojisp-container[data-active="pop"] > .char[data-category]:not([data-category="pop"]),
+.viewport > .main-container > .emojisp-container[data-active="other"] > .char[data-category]:not([data-category="other"]) {
     display: none;
 }
 

--- a/static/css/plugins/emojis.css
+++ b/static/css/plugins/emojis.css
@@ -53,6 +53,26 @@ body.ldj .welcome > .form.form-settings > .welcome-catalog > .settings-container
     margin: 0px 0px 16px 0px;
 }
 
+.welcome > .form.form-settings > .welcome-catalog > .settings-container > .settings-group > .emojis-actions > .button.button-ghost {
+    background-color: #f4f5f8;
+    border: none;
+    color: #4b5260;
+    text-align: center;
+}
+
+.welcome > .form.form-settings > .welcome-catalog > .settings-container > .settings-group > .emojis-actions > .button.button-ghost:hover {
+    background-color: #e7eaf0;
+}
+
+body.ldj .welcome > .form.form-settings > .welcome-catalog > .settings-container > .settings-group > .emojis-actions > .button.button-ghost {
+    border-color: #ece4f5;
+    color: #6b5a8a;
+}
+
+body.ldj .welcome > .form.form-settings > .welcome-catalog > .settings-container > .settings-group > .emojis-actions > .button.button-ghost:hover {
+    background-color: #f5f0fa;
+}
+
 .welcome > .form.form-settings > .welcome-catalog > .settings-container > .settings-group > .emojis-feedback {
     background-color: #f5f6f8;
     border-radius: 12px;

--- a/static/css/plugins/keyboard.css
+++ b/static/css/plugins/keyboard.css
@@ -143,10 +143,12 @@ body.ldj .viewport > .main-container > .emojisp-container > .emojis-tabs > .emoj
 .viewport > .main-container > .emojis-container[data-active="people"] > .char[data-category]:not([data-category="people"]),
 .viewport > .main-container > .emojis-container[data-active="pop"] > .char[data-category]:not([data-category="pop"]),
 .viewport > .main-container > .emojis-container[data-active="phrases"] > .char[data-category]:not([data-category="phrases"]),
+.viewport > .main-container > .emojis-container[data-active="other"] > .char[data-category]:not([data-category="other"]),
 .viewport > .main-container > .emojisp-container[data-active="symbols"] > .char[data-category]:not([data-category="symbols"]),
 .viewport > .main-container > .emojisp-container[data-active="nature"] > .char[data-category]:not([data-category="nature"]),
 .viewport > .main-container > .emojisp-container[data-active="people"] > .char[data-category]:not([data-category="people"]),
-.viewport > .main-container > .emojisp-container[data-active="pop"] > .char[data-category]:not([data-category="pop"]) {
+.viewport > .main-container > .emojisp-container[data-active="pop"] > .char[data-category]:not([data-category="pop"]),
+.viewport > .main-container > .emojisp-container[data-active="other"] > .char[data-category]:not([data-category="other"]) {
     display: none;
 }
 

--- a/static/fonts/coolemojis.mapping.json
+++ b/static/fonts/coolemojis.mapping.json
@@ -1,93 +1,453 @@
 {
-    "A": "1101.coracao",
-    "B": "1102.estrela",
-    "C": "1103.infinito",
-    "D": "1104.paz",
-    "E": "1105.aliancas",
-    "F": "1106.trevo",
-    "G": "1107.cruz",
-    "H": "1201.unicornio",
-    "I": "1202.cao",
-    "J": "1203.gato",
-    "K": "1204.borboleta",
-    "L": "1205.urso",
-    "M": "1301.smile",
-    "N": "1302.oculos",
-    "O": "1303.happy",
-    "P": "1304.menina",
-    "Q": "1305.menino",
-    "R": "1401.anjo",
-    "S": "1402.bola",
-    "T": "1403.arcoiris",
-    "U": "1404.onda",
-    "V": "1405.musica",
-    "W": "1406.camara",
-    "X": "1407.caveira",
-    "Y": "1408.raio",
-    "Z": "1409.chama",
-    "a": "1410.palmeira",
-    "b": "1411.trofeu",
-    "c": "1412.princesa",
-    "d": "1413.rei",
-    "e": "1414.flor",
-    "f": "1415.sabrinas",
-    "g": "1416.portugal",
-    "h": "1417.santiago",
-    "i": "1418.aprendizagem",
-    "j": "1419.sardinha",
-    "k": "1420.livro",
-    "l": "1501.gosto",
-    "m": "1502.vitoria",
-    "n": "1503.punho",
-    "o": "1504.metal",
-    "p": "1601.invaders",
-    "q": "1602.mario",
-    "r": "1603.fantasma",
-    "s": "1604.pacman",
-    "$": "1605.mickey",
-    "@": "1606.minnie",
-    "t": "1701.univ",
-    "u": "1702.medicina",
-    "v": "1703.direito",
-    "w": "1704.arquite",
-    "x": "1705.engenh",
-    "y": "1706.culina",
-    "z": "1707.informat",
-    ",": "1801.familia1",
-    "0": "1802.familia2",
-    "1": "1803.familia3",
-    "2": "1804.familiam1",
-    "3": "1805.familiam2",
-    "4": "1901.carneiro",
-    "5": "1902.touro",
-    "6": "1903.gemeos",
-    "7": "1904.carangueijo",
-    "8": "1905.leao",
-    "9": "1906.virgem",
-    "-": "1907.balanca",
-    "+": "1908.escorpiao",
-    "*": "1909.sagitario",
-    "^": "1910.capricornio",
-    "˜": "1911.aquario",
-    "/": "1912.peixes",
+    "0": {
+        "name": "1802.familia2",
+        "category": "people",
+        "order": 560
+    },
+    "1": {
+        "name": "1803.familia3",
+        "category": "people",
+        "order": 570
+    },
+    "2": {
+        "name": "1804.familiam1",
+        "category": "people",
+        "order": 580
+    },
+    "3": {
+        "name": "1805.familiam2",
+        "category": "people",
+        "order": 590
+    },
+    "4": {
+        "name": "1901.carneiro",
+        "category": "symbols",
+        "order": 710
+    },
+    "5": {
+        "name": "1902.touro",
+        "category": "symbols",
+        "order": 720
+    },
+    "6": {
+        "name": "1903.gemeos",
+        "category": "symbols",
+        "order": 730
+    },
+    "7": {
+        "name": "1904.carangueijo",
+        "category": "symbols",
+        "order": 740
+    },
+    "8": {
+        "name": "1905.leao",
+        "category": "symbols",
+        "order": 750
+    },
+    "9": {
+        "name": "1906.virgem",
+        "category": "symbols",
+        "order": 760
+    },
+    "A": {
+        "name": "1101.coracao",
+        "category": "symbols",
+        "order": 10
+    },
+    "B": {
+        "name": "1102.estrela",
+        "category": "symbols",
+        "order": 20
+    },
+    "C": {
+        "name": "1103.infinito",
+        "category": "symbols",
+        "order": 30
+    },
+    "D": {
+        "name": "1104.paz",
+        "category": "symbols",
+        "order": 40
+    },
+    "E": {
+        "name": "1105.aliancas",
+        "category": "symbols",
+        "order": 50
+    },
+    "F": {
+        "name": "1106.trevo",
+        "category": "symbols",
+        "order": 60
+    },
+    "G": {
+        "name": "1107.cruz",
+        "category": "symbols",
+        "order": 70
+    },
+    "H": {
+        "name": "1201.unicornio",
+        "category": "nature",
+        "order": 80
+    },
+    "I": {
+        "name": "1202.cao",
+        "category": "nature",
+        "order": 90
+    },
+    "J": {
+        "name": "1203.gato",
+        "category": "nature",
+        "order": 100
+    },
+    "K": {
+        "name": "1204.borboleta",
+        "category": "nature",
+        "order": 110
+    },
+    "L": {
+        "name": "1205.urso",
+        "category": "nature",
+        "order": 120
+    },
+    "M": {
+        "name": "1301.smile",
+        "category": "people",
+        "order": 130
+    },
+    "N": {
+        "name": "1302.oculos",
+        "category": "people",
+        "order": 140
+    },
+    "O": {
+        "name": "1303.happy",
+        "category": "people",
+        "order": 150
+    },
+    "P": {
+        "name": "1304.menina",
+        "category": "people",
+        "order": 160
+    },
+    "Q": {
+        "name": "1305.menino",
+        "category": "people",
+        "order": 170
+    },
+    "R": {
+        "name": "1401.anjo",
+        "category": "people",
+        "order": 180
+    },
+    "S": {
+        "name": "1402.bola",
+        "category": "symbols",
+        "order": 190
+    },
+    "T": {
+        "name": "1403.arcoiris",
+        "category": "symbols",
+        "order": 200
+    },
+    "U": {
+        "name": "1404.onda",
+        "category": "symbols",
+        "order": 210
+    },
+    "V": {
+        "name": "1405.musica",
+        "category": "symbols",
+        "order": 220
+    },
+    "W": {
+        "name": "1406.camara",
+        "category": "symbols",
+        "order": 230
+    },
+    "X": {
+        "name": "1407.caveira",
+        "category": "symbols",
+        "order": 240
+    },
+    "Y": {
+        "name": "1408.raio",
+        "category": "symbols",
+        "order": 250
+    },
+    "Z": {
+        "name": "1409.chama",
+        "category": "symbols",
+        "order": 260
+    },
+    "a": {
+        "name": "1410.palmeira",
+        "category": "nature",
+        "order": 270
+    },
+    "b": {
+        "name": "1411.trofeu",
+        "category": "symbols",
+        "order": 280
+    },
+    "c": {
+        "name": "1412.princesa",
+        "category": "people",
+        "order": 290
+    },
+    "d": {
+        "name": "1413.rei",
+        "category": "people",
+        "order": 300
+    },
+    "e": {
+        "name": "1414.flor",
+        "category": "symbols",
+        "order": 310
+    },
+    "f": {
+        "name": "1415.sabrinas",
+        "category": "pop",
+        "order": 320
+    },
+    "g": {
+        "name": "1416.portugal",
+        "category": "pop",
+        "order": 330
+    },
+    "h": {
+        "name": "1417.santiago",
+        "category": "pop",
+        "order": 340
+    },
+    "i": {
+        "name": "1418.aprendizagem",
+        "category": "pop",
+        "order": 350
+    },
+    "j": {
+        "name": "1419.sardinha",
+        "category": "nature",
+        "order": 360
+    },
+    "k": {
+        "name": "1420.livro",
+        "category": "pop",
+        "order": 370
+    },
+    "l": {
+        "name": "1501.gosto",
+        "category": "people",
+        "order": 380
+    },
+    "m": {
+        "name": "1502.vitoria",
+        "category": "people",
+        "order": 390
+    },
+    "n": {
+        "name": "1503.punho",
+        "category": "people",
+        "order": 400
+    },
+    "o": {
+        "name": "1504.metal",
+        "category": "people",
+        "order": 410
+    },
+    "p": {
+        "name": "1601.invaders",
+        "category": "pop",
+        "order": 420
+    },
+    "q": {
+        "name": "1602.mario",
+        "category": "pop",
+        "order": 430
+    },
+    "r": {
+        "name": "1603.fantasma",
+        "category": "pop",
+        "order": 440
+    },
+    "s": {
+        "name": "1604.pacman",
+        "category": "pop",
+        "order": 450
+    },
+    "$": {
+        "name": "1605.mickey",
+        "category": "pop",
+        "order": 460
+    },
+    "@": {
+        "name": "1606.minnie",
+        "category": "pop",
+        "order": 470
+    },
+    "t": {
+        "name": "1701.univ",
+        "category": "pop",
+        "order": 480
+    },
+    "u": {
+        "name": "1702.medicina",
+        "category": "pop",
+        "order": 490
+    },
+    "v": {
+        "name": "1703.direito",
+        "category": "pop",
+        "order": 500
+    },
+    "w": {
+        "name": "1704.arquite",
+        "category": "pop",
+        "order": 510
+    },
+    "x": {
+        "name": "1705.engenh",
+        "category": "pop",
+        "order": 520
+    },
+    "y": {
+        "name": "1706.culina",
+        "category": "pop",
+        "order": 530
+    },
+    "z": {
+        "name": "1707.informat",
+        "category": "pop",
+        "order": 540
+    },
+    ",": {
+        "name": "1801.familia1",
+        "category": "people",
+        "order": 550
+    },
+    "-": {
+        "name": "1907.balanca",
+        "category": "symbols",
+        "order": 770
+    },
+    "+": {
+        "name": "1908.escorpiao",
+        "category": "symbols",
+        "order": 780
+    },
+    "*": {
+        "name": "1909.sagitario",
+        "category": "symbols",
+        "order": 790
+    },
+    "^": {
+        "name": "1910.capricornio",
+        "category": "symbols",
+        "order": 800
+    },
+    "˜": {
+        "name": "1911.aquario",
+        "category": "symbols",
+        "order": 810
+    },
+    "/": {
+        "name": "1912.peixes",
+        "category": "symbols",
+        "order": 820
+    },
     "€": "2101.myqueen",
-    "%": "2102.myking",
-    "&": "2103.amote",
-    "(": "2104.strong",
-    "|": "2105.special",
-    ")": "2106.forever",
-    "{": "2107.you&me",
-    "}": "2108.bornfree",
-    "[": "2109.byourself",
-    "\\": "3001.pai1-familia",
-    ":": "3002.pai2-familia",
-    ";": "3003.mae1-familia",
-    "<": "3004.mae2-familia",
-    "=": "3005.avoo-familia",
-    ">": "3006.avo-familia",
-    "!": "3007.filho-familia",
-    "?": "3008.filha-familia",
-    "'": "3009.bebe-familia",
-    "\"": "3010.cao-familia",
-    "#": "3011.gato-familia"
+    "%": {
+        "name": "2102.myking",
+        "category": "phrases",
+        "order": 830
+    },
+    "&": {
+        "name": "2103.amote",
+        "category": "phrases",
+        "order": 840
+    },
+    "(": {
+        "name": "2104.strong",
+        "category": "phrases",
+        "order": 850
+    },
+    "|": {
+        "name": "2105.special",
+        "category": "phrases",
+        "order": 890
+    },
+    ")": {
+        "name": "2106.forever",
+        "category": "phrases",
+        "order": 860
+    },
+    "{": {
+        "name": "2107.you&me",
+        "category": "phrases",
+        "order": 880
+    },
+    "}": {
+        "name": "2108.bornfree",
+        "category": "phrases",
+        "order": 900
+    },
+    "[": {
+        "name": "2109.byourself",
+        "category": "phrases",
+        "order": 870
+    },
+    "\\": {
+        "name": "3001.pai1-familia",
+        "category": "people",
+        "order": 600
+    },
+    ":": {
+        "name": "3002.pai2-familia",
+        "category": "people",
+        "order": 610
+    },
+    ";": {
+        "name": "3003.mae1-familia",
+        "category": "people",
+        "order": 620
+    },
+    "<": {
+        "name": "3004.mae2-familia",
+        "category": "people",
+        "order": 630
+    },
+    "=": {
+        "name": "3005.avoo-familia",
+        "category": "people",
+        "order": 640
+    },
+    ">": {
+        "name": "3006.avo-familia",
+        "category": "people",
+        "order": 650
+    },
+    "!": {
+        "name": "3007.filho-familia",
+        "category": "people",
+        "order": 660
+    },
+    "?": {
+        "name": "3008.filha-familia",
+        "category": "people",
+        "order": 670
+    },
+    "'": {
+        "name": "3009.bebe-familia",
+        "category": "people",
+        "order": 680
+    },
+    "\"": {
+        "name": "3010.cao-familia",
+        "category": "people",
+        "order": 690
+    },
+    "#": {
+        "name": "3011.gato-familia",
+        "category": "people",
+        "order": 700
+    }
 }

--- a/static/js/bundle.js
+++ b/static/js/bundle.js
@@ -6044,36 +6044,6 @@ jQuery(document).ready(function() {
             if (onComplete) onComplete();
         }, 250);
     };
-    const viewportContainer = jQuery(".viewer-container");
-    const calligraphyContainer = jQuery(".calligraphy-container");
-    const calligraphyMode = jQuery(".calligraphy-mode");
-    const calligraphyModeContainer = jQuery(".calligraphy-mode-container");
-    const calligraphyControls = jQuery(".calligraphy-controls");
-    const calligraphyUndo = jQuery(".calligraphy-undo");
-    const calligraphyClear = jQuery(".calligraphy-clear");
-    const calligraphyThicknessContainer = jQuery(".calligraphy-thickness-container");
-    const calligraphyThicknessRange = jQuery(".calligraphy-thickness-range");
-    const calligraphyThicknessPresets = jQuery(".calligraphy-thickness-preset");
-    const calligraphyThicknessBubble = jQuery(".calligraphy-thickness-bubble");
-    const formConsole = jQuery(".form-console");
-    const inputViewport = jQuery(".input-viewport");
-    const signature = jQuery(".signature");
-    const modalOverlayError = jQuery(".modal-overlay-error");
-    const modalOverlayConfirm = jQuery(".modal-overlay-confirm");
-    const modalOverlayInspirations = jQuery(".modal-overlay-inspirations");
-    const modalOverlayPrintJob = jQuery(".modal-overlay-print-job");
-    const modalOverlayFeedback = jQuery(".modal-overlay-feedback");
-    const inspirationPanel = jQuery(".inspiration-panel");
-    const toast = jQuery(".toast");
-
-    // gathers the values for the form related fields so that the
-    // typical form validations and changes may be performed
-    const technologyRadios = jQuery("input[name=technology]");
-    const technologySelected = jQuery("input[name=technology]:checked");
-    const elementsE = jQuery("[id=elements]");
-    const locationE = jQuery("[id=location]");
-    const elementsChild = jQuery("> *", elementsE);
-    const locationChild = jQuery("> *", locationE);
 
     // the reserved category that gathers every mapping entry left
     // without an explicit one so uncategorized glyphs surface in
@@ -6171,6 +6141,37 @@ jQuery(document).ready(function() {
             key.insertBefore(anchor);
         }
     };
+
+    const viewportContainer = jQuery(".viewer-container");
+    const calligraphyContainer = jQuery(".calligraphy-container");
+    const calligraphyMode = jQuery(".calligraphy-mode");
+    const calligraphyModeContainer = jQuery(".calligraphy-mode-container");
+    const calligraphyControls = jQuery(".calligraphy-controls");
+    const calligraphyUndo = jQuery(".calligraphy-undo");
+    const calligraphyClear = jQuery(".calligraphy-clear");
+    const calligraphyThicknessContainer = jQuery(".calligraphy-thickness-container");
+    const calligraphyThicknessRange = jQuery(".calligraphy-thickness-range");
+    const calligraphyThicknessPresets = jQuery(".calligraphy-thickness-preset");
+    const calligraphyThicknessBubble = jQuery(".calligraphy-thickness-bubble");
+    const formConsole = jQuery(".form-console");
+    const inputViewport = jQuery(".input-viewport");
+    const signature = jQuery(".signature");
+    const modalOverlayError = jQuery(".modal-overlay-error");
+    const modalOverlayConfirm = jQuery(".modal-overlay-confirm");
+    const modalOverlayInspirations = jQuery(".modal-overlay-inspirations");
+    const modalOverlayPrintJob = jQuery(".modal-overlay-print-job");
+    const modalOverlayFeedback = jQuery(".modal-overlay-feedback");
+    const inspirationPanel = jQuery(".inspiration-panel");
+    const toast = jQuery(".toast");
+
+    // gathers the values for the form related fields so that the
+    // typical form validations and changes may be performed
+    const technologyRadios = jQuery("input[name=technology]");
+    const technologySelected = jQuery("input[name=technology]:checked");
+    const elementsE = jQuery("[id=elements]");
+    const locationE = jQuery("[id=location]");
+    const elementsChild = jQuery("> *", elementsE);
+    const locationChild = jQuery("> *", locationE);
 
     // loads the cool emojis mapping from the static fonts directory
     // to resolve emoji characters to font names and lay out the

--- a/static/js/bundle.js
+++ b/static/js/bundle.js
@@ -1913,8 +1913,10 @@ const countLines = function(text) {
             const fontSpec = entry[0];
             const char = entry[1];
             if (fontSpec === "Cool Emojis") {
-                if (mapping[char]) {
-                    result.push([mapping[char], "a"]);
+                const entry = mapping[char];
+                const mapped = typeof entry === "object" && entry !== null ? entry.name : entry;
+                if (mapped) {
+                    result.push([mapped, "a"]);
                 } else if (char === " ") {
                     result.push(["HELVETICA 4L", " "]);
                 }
@@ -6050,16 +6052,27 @@ jQuery(document).ready(function() {
     // their own tab instead of disappearing into a real category
     const EMOJI_OTHER_CATEGORY = "other";
 
+    // the categories the keyboard CSS knows how to filter through the
+    // `data-active` selector list, kept in sync with the rules in
+    // `static/css/plugins/keyboard.css` so a tab is only ever created
+    // for a category whose non matching keys can actually be hidden
+    const EMOJI_CATEGORIES = ["symbols", "nature", "people", "pop", "phrases"];
+
     // normalizes a single mapping value into the object form so the
     // grid generation can treat the plain string shape and the
-    // extended object shape uniformly, falling back to the reserved
-    // category for entries that do not declare one
+    // extended object shape uniformly, folding both the missing and
+    // the unknown categories into the reserved one so every tab the
+    // grid renders has a matching filter rule on the CSS side
     const normalizeEmojiEntry = function(value, entry) {
         const object = typeof entry === "string" ? { name: entry } : entry || {};
+        const category =
+            EMOJI_CATEGORIES.indexOf(object.category) === -1
+                ? EMOJI_OTHER_CATEGORY
+                : object.category;
         return {
             value: value,
             name: object.name,
-            category: object.category || EMOJI_OTHER_CATEGORY,
+            category: category,
             order: object.order
         };
     };

--- a/static/js/bundle.js
+++ b/static/js/bundle.js
@@ -97,7 +97,8 @@ const multifontText = function(text, emojiMapping) {
             continue;
         }
         if (font === "Cool Emojis") {
-            const mapped = emojiMapping[value];
+            const entry = emojiMapping[value];
+            const mapped = typeof entry === "object" && entry !== null ? entry.name : entry;
             if (mapped) {
                 result.push([mapped, "a"]);
             } else if (value === " ") {
@@ -6074,17 +6075,117 @@ jQuery(document).ready(function() {
     const elementsChild = jQuery("> *", elementsE);
     const locationChild = jQuery("> *", locationE);
 
-    // loads the cool emojis mapping from the static fonts
-    // directory to resolve emoji characters to font names
+    // the reserved category that gathers every mapping entry left
+    // without an explicit one so uncategorized glyphs surface in
+    // their own tab instead of disappearing into a real category
+    const EMOJI_OTHER_CATEGORY = "other";
+
+    // normalizes a single mapping value into the object form so the
+    // grid generation can treat the plain string shape and the
+    // extended object shape uniformly, falling back to the reserved
+    // category for entries that do not declare one
+    const normalizeEmojiEntry = function(value, entry) {
+        const object = typeof entry === "string" ? { name: entry } : entry || {};
+        return {
+            value: value,
+            name: object.name,
+            category: object.category || EMOJI_OTHER_CATEGORY,
+            order: object.order
+        };
+    };
+
+    // turns the cool emojis mapping into the ordered list of entries
+    // backing the keyboard, sorting the ones that declare an order
+    // ahead of the rest while keeping the mapping key order otherwise
+    const emojiEntries = function(mapping) {
+        const entries = Object.keys(mapping).map(function(value, index) {
+            const entry = normalizeEmojiEntry(value, mapping[value]);
+            entry.index = index;
+            return entry;
+        });
+        entries.sort(function(first, second) {
+            const firstOrder = first.order === undefined ? Infinity : first.order;
+            const secondOrder = second.order === undefined ? Infinity : second.order;
+            if (firstOrder !== secondOrder) return firstOrder - secondOrder;
+            return first.index - second.index;
+        });
+        return entries;
+    };
+
+    // collects the distinct categories from the entries in first seen
+    // order, appending the reserved catch all category last and only
+    // when at least one entry actually falls back to it
+    const emojiCategories = function(entries) {
+        const categories = [];
+        let hasOther = false;
+        for (const entry of entries) {
+            if (entry.category === EMOJI_OTHER_CATEGORY) {
+                hasOther = true;
+                continue;
+            }
+            if (categories.indexOf(entry.category) === -1) categories.push(entry.category);
+        }
+        if (hasOther) categories.push(EMOJI_OTHER_CATEGORY);
+        return categories;
+    };
+
+    // resolves the display label for a category from the localized
+    // `data-label-<category>` attributes the template carries, falling
+    // back to a title cased form so admin defined categories and the
+    // reserved catch all one still render a sensible tab label
+    const emojiCategoryLabel = function(container, category) {
+        const label = container.attr("data-label-" + category);
+        if (label) return label;
+        return category.charAt(0).toUpperCase() + category.slice(1);
+    };
+
+    // builds the tab strip and the per glyph keys for the emojis
+    // container from the mapping, mirroring the markup the viewport
+    // template used to ship so the existing keyboard plugin can keep
+    // discovering its children by the same class convention; the
+    // generated nodes are inserted ahead of the trailing utility keys
+    // (backspace, space and enter) that the template still ships
+    const buildEmojisContainer = function(container, mapping) {
+        const entries = emojiEntries(mapping);
+        const categories = emojiCategories(entries);
+        const anchor = jQuery("> br", container).first();
+
+        const tabs = jQuery('<div class="emojis-tabs"></div>');
+        for (let index = 0; index < categories.length; index++) {
+            const category = categories[index];
+            const tab = jQuery('<span class="emojis-tab"></span>');
+            if (index === 0) tab.addClass("active");
+            tab.attr("data-category", category);
+            tab.text(emojiCategoryLabel(container, category));
+            tabs.append(tab);
+        }
+        tabs.insertBefore(anchor);
+        container.attr("data-active", categories[0] || EMOJI_OTHER_CATEGORY);
+
+        for (const entry of entries) {
+            const key = jQuery('<span class="char"></span>');
+            key.attr("data-category", entry.category);
+            key.attr("data-value", entry.value);
+            key.text(entry.value);
+            if (entry.name) key.attr("title", entry.name);
+            key.insertBefore(anchor);
+        }
+    };
+
+    // loads the cool emojis mapping from the static fonts directory
+    // to resolve emoji characters to font names and lay out the
+    // emojis keyboard from the same mapping the upload replaces
     let emojiMapping = {};
     jQuery.getJSON("/static/fonts/coolemojis.mapping.json", function(data) {
         emojiMapping = data;
-        emojisContainer.find(".char[data-value]").each(function() {
-            const element = jQuery(this);
-            const value = element.attr("data-value");
-            const font = emojiMapping[value];
-            if (font) element.attr("title", font);
-        });
+        buildEmojisContainer(emojisContainer, emojiMapping);
+        emojisContainer.keyboardcontainer();
+        restoreText();
+    }).fail(function() {
+        // degrades to an empty emoji grid when the mapping cannot be
+        // fetched, still wiring the container so its utility keys keep
+        // working and never blocking the rest of the viewport restore
+        emojisContainer.keyboardcontainer();
         restoreText();
     });
 
@@ -7585,8 +7686,10 @@ jQuery(document).ready(function() {
         }
     };
 
+    // the emojis container is initialized from the getJSON callback
+    // once its mapping driven grid has been built, so only the static
+    // keyboards are wired up here on plain initialization
     keyboardContainer.keyboardcontainer();
-    emojisContainer.keyboardcontainer();
     emojispContainer.keyboardcontainer();
 
     modalOverlayError.modal();

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -223,36 +223,6 @@ jQuery(document).ready(function() {
             if (onComplete) onComplete();
         }, 250);
     };
-    const viewportContainer = jQuery(".viewer-container");
-    const calligraphyContainer = jQuery(".calligraphy-container");
-    const calligraphyMode = jQuery(".calligraphy-mode");
-    const calligraphyModeContainer = jQuery(".calligraphy-mode-container");
-    const calligraphyControls = jQuery(".calligraphy-controls");
-    const calligraphyUndo = jQuery(".calligraphy-undo");
-    const calligraphyClear = jQuery(".calligraphy-clear");
-    const calligraphyThicknessContainer = jQuery(".calligraphy-thickness-container");
-    const calligraphyThicknessRange = jQuery(".calligraphy-thickness-range");
-    const calligraphyThicknessPresets = jQuery(".calligraphy-thickness-preset");
-    const calligraphyThicknessBubble = jQuery(".calligraphy-thickness-bubble");
-    const formConsole = jQuery(".form-console");
-    const inputViewport = jQuery(".input-viewport");
-    const signature = jQuery(".signature");
-    const modalOverlayError = jQuery(".modal-overlay-error");
-    const modalOverlayConfirm = jQuery(".modal-overlay-confirm");
-    const modalOverlayInspirations = jQuery(".modal-overlay-inspirations");
-    const modalOverlayPrintJob = jQuery(".modal-overlay-print-job");
-    const modalOverlayFeedback = jQuery(".modal-overlay-feedback");
-    const inspirationPanel = jQuery(".inspiration-panel");
-    const toast = jQuery(".toast");
-
-    // gathers the values for the form related fields so that the
-    // typical form validations and changes may be performed
-    const technologyRadios = jQuery("input[name=technology]");
-    const technologySelected = jQuery("input[name=technology]:checked");
-    const elementsE = jQuery("[id=elements]");
-    const locationE = jQuery("[id=location]");
-    const elementsChild = jQuery("> *", elementsE);
-    const locationChild = jQuery("> *", locationE);
 
     // the reserved category that gathers every mapping entry left
     // without an explicit one so uncategorized glyphs surface in
@@ -350,6 +320,37 @@ jQuery(document).ready(function() {
             key.insertBefore(anchor);
         }
     };
+
+    const viewportContainer = jQuery(".viewer-container");
+    const calligraphyContainer = jQuery(".calligraphy-container");
+    const calligraphyMode = jQuery(".calligraphy-mode");
+    const calligraphyModeContainer = jQuery(".calligraphy-mode-container");
+    const calligraphyControls = jQuery(".calligraphy-controls");
+    const calligraphyUndo = jQuery(".calligraphy-undo");
+    const calligraphyClear = jQuery(".calligraphy-clear");
+    const calligraphyThicknessContainer = jQuery(".calligraphy-thickness-container");
+    const calligraphyThicknessRange = jQuery(".calligraphy-thickness-range");
+    const calligraphyThicknessPresets = jQuery(".calligraphy-thickness-preset");
+    const calligraphyThicknessBubble = jQuery(".calligraphy-thickness-bubble");
+    const formConsole = jQuery(".form-console");
+    const inputViewport = jQuery(".input-viewport");
+    const signature = jQuery(".signature");
+    const modalOverlayError = jQuery(".modal-overlay-error");
+    const modalOverlayConfirm = jQuery(".modal-overlay-confirm");
+    const modalOverlayInspirations = jQuery(".modal-overlay-inspirations");
+    const modalOverlayPrintJob = jQuery(".modal-overlay-print-job");
+    const modalOverlayFeedback = jQuery(".modal-overlay-feedback");
+    const inspirationPanel = jQuery(".inspiration-panel");
+    const toast = jQuery(".toast");
+
+    // gathers the values for the form related fields so that the
+    // typical form validations and changes may be performed
+    const technologyRadios = jQuery("input[name=technology]");
+    const technologySelected = jQuery("input[name=technology]:checked");
+    const elementsE = jQuery("[id=elements]");
+    const locationE = jQuery("[id=location]");
+    const elementsChild = jQuery("> *", elementsE);
+    const locationChild = jQuery("> *", locationE);
 
     // loads the cool emojis mapping from the static fonts directory
     // to resolve emoji characters to font names and lay out the

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -254,17 +254,117 @@ jQuery(document).ready(function() {
     const elementsChild = jQuery("> *", elementsE);
     const locationChild = jQuery("> *", locationE);
 
-    // loads the cool emojis mapping from the static fonts
-    // directory to resolve emoji characters to font names
+    // the reserved category that gathers every mapping entry left
+    // without an explicit one so uncategorized glyphs surface in
+    // their own tab instead of disappearing into a real category
+    const EMOJI_OTHER_CATEGORY = "other";
+
+    // normalizes a single mapping value into the object form so the
+    // grid generation can treat the plain string shape and the
+    // extended object shape uniformly, falling back to the reserved
+    // category for entries that do not declare one
+    const normalizeEmojiEntry = function(value, entry) {
+        const object = typeof entry === "string" ? { name: entry } : entry || {};
+        return {
+            value: value,
+            name: object.name,
+            category: object.category || EMOJI_OTHER_CATEGORY,
+            order: object.order
+        };
+    };
+
+    // turns the cool emojis mapping into the ordered list of entries
+    // backing the keyboard, sorting the ones that declare an order
+    // ahead of the rest while keeping the mapping key order otherwise
+    const emojiEntries = function(mapping) {
+        const entries = Object.keys(mapping).map(function(value, index) {
+            const entry = normalizeEmojiEntry(value, mapping[value]);
+            entry.index = index;
+            return entry;
+        });
+        entries.sort(function(first, second) {
+            const firstOrder = first.order === undefined ? Infinity : first.order;
+            const secondOrder = second.order === undefined ? Infinity : second.order;
+            if (firstOrder !== secondOrder) return firstOrder - secondOrder;
+            return first.index - second.index;
+        });
+        return entries;
+    };
+
+    // collects the distinct categories from the entries in first seen
+    // order, appending the reserved catch all category last and only
+    // when at least one entry actually falls back to it
+    const emojiCategories = function(entries) {
+        const categories = [];
+        let hasOther = false;
+        for (const entry of entries) {
+            if (entry.category === EMOJI_OTHER_CATEGORY) {
+                hasOther = true;
+                continue;
+            }
+            if (categories.indexOf(entry.category) === -1) categories.push(entry.category);
+        }
+        if (hasOther) categories.push(EMOJI_OTHER_CATEGORY);
+        return categories;
+    };
+
+    // resolves the display label for a category from the localized
+    // `data-label-<category>` attributes the template carries, falling
+    // back to a title cased form so admin defined categories and the
+    // reserved catch all one still render a sensible tab label
+    const emojiCategoryLabel = function(container, category) {
+        const label = container.attr("data-label-" + category);
+        if (label) return label;
+        return category.charAt(0).toUpperCase() + category.slice(1);
+    };
+
+    // builds the tab strip and the per glyph keys for the emojis
+    // container from the mapping, mirroring the markup the viewport
+    // template used to ship so the existing keyboard plugin can keep
+    // discovering its children by the same class convention; the
+    // generated nodes are inserted ahead of the trailing utility keys
+    // (backspace, space and enter) that the template still ships
+    const buildEmojisContainer = function(container, mapping) {
+        const entries = emojiEntries(mapping);
+        const categories = emojiCategories(entries);
+        const anchor = jQuery("> br", container).first();
+
+        const tabs = jQuery('<div class="emojis-tabs"></div>');
+        for (let index = 0; index < categories.length; index++) {
+            const category = categories[index];
+            const tab = jQuery('<span class="emojis-tab"></span>');
+            if (index === 0) tab.addClass("active");
+            tab.attr("data-category", category);
+            tab.text(emojiCategoryLabel(container, category));
+            tabs.append(tab);
+        }
+        tabs.insertBefore(anchor);
+        container.attr("data-active", categories[0] || EMOJI_OTHER_CATEGORY);
+
+        for (const entry of entries) {
+            const key = jQuery('<span class="char"></span>');
+            key.attr("data-category", entry.category);
+            key.attr("data-value", entry.value);
+            key.text(entry.value);
+            if (entry.name) key.attr("title", entry.name);
+            key.insertBefore(anchor);
+        }
+    };
+
+    // loads the cool emojis mapping from the static fonts directory
+    // to resolve emoji characters to font names and lay out the
+    // emojis keyboard from the same mapping the upload replaces
     let emojiMapping = {};
     jQuery.getJSON("/static/fonts/coolemojis.mapping.json", function(data) {
         emojiMapping = data;
-        emojisContainer.find(".char[data-value]").each(function() {
-            const element = jQuery(this);
-            const value = element.attr("data-value");
-            const font = emojiMapping[value];
-            if (font) element.attr("title", font);
-        });
+        buildEmojisContainer(emojisContainer, emojiMapping);
+        emojisContainer.keyboardcontainer();
+        restoreText();
+    }).fail(function() {
+        // degrades to an empty emoji grid when the mapping cannot be
+        // fetched, still wiring the container so its utility keys keep
+        // working and never blocking the rest of the viewport restore
+        emojisContainer.keyboardcontainer();
         restoreText();
     });
 
@@ -1765,8 +1865,10 @@ jQuery(document).ready(function() {
         }
     };
 
+    // the emojis container is initialized from the getJSON callback
+    // once its mapping driven grid has been built, so only the static
+    // keyboards are wired up here on plain initialization
     keyboardContainer.keyboardcontainer();
-    emojisContainer.keyboardcontainer();
     emojispContainer.keyboardcontainer();
 
     modalOverlayError.modal();

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -229,16 +229,27 @@ jQuery(document).ready(function() {
     // their own tab instead of disappearing into a real category
     const EMOJI_OTHER_CATEGORY = "other";
 
+    // the categories the keyboard CSS knows how to filter through the
+    // `data-active` selector list, kept in sync with the rules in
+    // `static/css/plugins/keyboard.css` so a tab is only ever created
+    // for a category whose non matching keys can actually be hidden
+    const EMOJI_CATEGORIES = ["symbols", "nature", "people", "pop", "phrases"];
+
     // normalizes a single mapping value into the object form so the
     // grid generation can treat the plain string shape and the
-    // extended object shape uniformly, falling back to the reserved
-    // category for entries that do not declare one
+    // extended object shape uniformly, folding both the missing and
+    // the unknown categories into the reserved one so every tab the
+    // grid renders has a matching filter rule on the CSS side
     const normalizeEmojiEntry = function(value, entry) {
         const object = typeof entry === "string" ? { name: entry } : entry || {};
+        const category =
+            EMOJI_CATEGORIES.indexOf(object.category) === -1
+                ? EMOJI_OTHER_CATEGORY
+                : object.category;
         return {
             value: value,
             name: object.name,
-            category: object.category || EMOJI_OTHER_CATEGORY,
+            category: category,
             order: object.order
         };
     };

--- a/static/js/plugins/modal.js
+++ b/static/js/plugins/modal.js
@@ -49,8 +49,10 @@
             const fontSpec = entry[0];
             const char = entry[1];
             if (fontSpec === "Cool Emojis") {
-                if (mapping[char]) {
-                    result.push([mapping[char], "a"]);
+                const entry = mapping[char];
+                const mapped = typeof entry === "object" && entry !== null ? entry.name : entry;
+                if (mapped) {
+                    result.push([mapped, "a"]);
                 } else if (char === " ") {
                     result.push(["HELVETICA 4L", " "]);
                 }

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -97,7 +97,8 @@ const multifontText = function(text, emojiMapping) {
             continue;
         }
         if (font === "Cool Emojis") {
-            const mapped = emojiMapping[value];
+            const entry = emojiMapping[value];
+            const mapped = typeof entry === "object" && entry !== null ? entry.name : entry;
             if (mapped) {
                 result.push([mapped, "a"]);
             } else if (value === " ") {

--- a/test/lib/smoke.js
+++ b/test/lib/smoke.js
@@ -297,6 +297,17 @@ describe("Smoke", function() {
         });
     });
 
+    describe("#settingsEmojisMapping()", function() {
+        it("should stream the mapping with the download filename", async () => {
+            const response = await request("GET", "/settings/emojis/mapping");
+            assert.strictEqual(response.status, 200);
+            assert.strictEqual(response.headers["content-type"], "application/json");
+            assert.ok(
+                (response.headers["content-disposition"] || "").includes("coolemojis.mapping.json")
+            );
+        });
+    });
+
     describe("#profiles()", function() {
         it("should return the profiles catalog as JSON", async () => {
             const response = await request("GET", "/profiles");

--- a/test/lib/util/emojis.js
+++ b/test/lib/util/emojis.js
@@ -179,5 +179,12 @@ describe("Emojis", function() {
             }));
             assert.deepStrictEqual(errors, ["mapping entry \"A\" must have a numeric \"order\""]);
         });
+
+        it("should reject an object entry with a non-finite order", () => {
+            const errors = lib.validateEmojisMapping(
+                "{ \"A\": { \"name\": \"1101.coracao\", \"order\": 1e309 } }"
+            );
+            assert.deepStrictEqual(errors, ["mapping entry \"A\" must have a numeric \"order\""]);
+        });
     });
 });

--- a/test/lib/util/emojis.js
+++ b/test/lib/util/emojis.js
@@ -129,12 +129,55 @@ describe("Emojis", function() {
             assert.deepStrictEqual(errors, ["mapping must be a plain object"]);
         });
 
-        it("should reject entries with non-string values", () => {
+        it("should validate the extended object form", () => {
+            const errors = lib.validateEmojisMapping(JSON.stringify({
+                A: { name: "1101.coracao", category: "nature", order: 10 },
+                B: "1102.estrela"
+            }));
+            assert.deepStrictEqual(errors, []);
+        });
+
+        it("should validate the object form without category or order", () => {
+            const errors = lib.validateEmojisMapping(JSON.stringify({
+                A: { name: "1101.coracao" }
+            }));
+            assert.deepStrictEqual(errors, []);
+        });
+
+        it("should reject entries that are neither string nor object", () => {
             const errors = lib.validateEmojisMapping(JSON.stringify({
                 A: "1101.coracao",
                 B: 42
             }));
-            assert.deepStrictEqual(errors, ["mapping entry \"B\" must be a string"]);
+            assert.deepStrictEqual(errors, ["mapping entry \"B\" must be a string or an object"]);
+        });
+
+        it("should reject an array entry", () => {
+            const errors = lib.validateEmojisMapping(JSON.stringify({
+                A: ["1101.coracao"]
+            }));
+            assert.deepStrictEqual(errors, ["mapping entry \"A\" must be a string or an object"]);
+        });
+
+        it("should reject an object entry without a string name", () => {
+            const errors = lib.validateEmojisMapping(JSON.stringify({
+                A: { category: "nature" }
+            }));
+            assert.deepStrictEqual(errors, ["mapping entry \"A\" must have a string \"name\""]);
+        });
+
+        it("should reject an object entry with a non-string category", () => {
+            const errors = lib.validateEmojisMapping(JSON.stringify({
+                A: { name: "1101.coracao", category: 7 }
+            }));
+            assert.deepStrictEqual(errors, ["mapping entry \"A\" must have a string \"category\""]);
+        });
+
+        it("should reject an object entry with a non-numeric order", () => {
+            const errors = lib.validateEmojisMapping(JSON.stringify({
+                A: { name: "1101.coracao", order: "10" }
+            }));
+            assert.deepStrictEqual(errors, ["mapping entry \"A\" must have a numeric \"order\""]);
         });
     });
 });

--- a/views/settings-pt_pt.ejs
+++ b/views/settings-pt_pt.ejs
@@ -229,7 +229,7 @@
                          data-label-f3s-network-error="O pedido falhou. O servidor pode estar inacessível.">
                         <div class="settings-group">
                             <div class="settings-group-label">Cool Emojis (visualização)</div>
-                            <div class="emojis-hint">Substitui a letra <code>coolemojis.ttf</code> incluída e, opcionalmente, o ficheiro <code>coolemojis.mapping.json</code> companheiro pelos ficheiros carregados. A próxima abertura do editor já mostra os novos glifos.</div>
+                            <div class="emojis-hint">Substitui a letra <code>coolemojis.ttf</code> incluída e, opcionalmente, o ficheiro <code>coolemojis.mapping.json</code> companheiro pelos ficheiros carregados. O mapeamento também define a disposição do teclado de emojis: cada entrada pode ser o nome do glifo ou um objecto com <code>category</code> e <code>order</code>, e as entradas sem categoria ficam num separador "Outros" dedicado. A próxima abertura do editor já mostra os novos glifos e a nova disposição.</div>
                             <div class="emojis-field">
                                 <label class="emojis-field-label" for="emojis-font">Letra (.ttf, .otf)</label>
                                 <input class="emojis-field-input" id="emojis-font" type="file" accept=".ttf,.otf" />
@@ -240,6 +240,7 @@
                             </div>
                             <div class="emojis-actions">
                                 <button type="button" class="button button-start emojis-upload">Carregar</button>
+                                <a class="button button-ghost emojis-mapping-download" href="/settings/emojis/mapping" download="coolemojis.mapping.json">Transferir actual</a>
                             </div>
                             <div class="emojis-feedback" hidden></div>
                         </div>

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -229,7 +229,7 @@
                          data-label-f3s-network-error="The request failed. The server may be unreachable.">
                         <div class="settings-group">
                             <div class="settings-group-label">Cool Emojis (display)</div>
-                            <div class="emojis-hint">Replaces the bundled <code>coolemojis.ttf</code> display font and, optionally, the companion <code>coolemojis.mapping.json</code> with freshly uploaded payloads. The next viewport load picks the new glyphs up.</div>
+                            <div class="emojis-hint">Replaces the bundled <code>coolemojis.ttf</code> display font and, optionally, the companion <code>coolemojis.mapping.json</code> with freshly uploaded payloads. The mapping also drives the emoji keyboard layout: an entry may be the plain glyph name or an object carrying a <code>category</code> and an <code>order</code>, and entries without a category land on a dedicated "Other" tab. The next viewport load picks the new glyphs and layout up.</div>
                             <div class="emojis-field">
                                 <label class="emojis-field-label" for="emojis-font">Font (.ttf, .otf)</label>
                                 <input class="emojis-field-input" id="emojis-font" type="file" accept=".ttf,.otf" />
@@ -240,6 +240,7 @@
                             </div>
                             <div class="emojis-actions">
                                 <button type="button" class="button button-start emojis-upload">Upload</button>
+                                <a class="button button-ghost emojis-mapping-download" href="/settings/emojis/mapping" download="coolemojis.mapping.json">Download current</a>
                             </div>
                             <div class="emojis-feedback" hidden></div>
                         </div>

--- a/views/viewport-pt_pt.ejs
+++ b/views/viewport-pt_pt.ejs
@@ -331,104 +331,13 @@
                     <span class="char utility" data-value="⎵" style="min-width: 340px;"><svg class="keyboard-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M22 17v1c0 .5-.5 1-1 1H3c-.5 0-1-.5-1-1v-1"/></svg></span>
                     <span class="char utility" data-value="↵" style="min-width: 66px;"><svg class="keyboard-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M20 4v7a4 4 0 0 1-4 4H4"/><path d="m9 10-5 5 5 5"/></svg></span>
                 </div>
-                <div class="emojis-container" data-active="symbols">
-                    <div class="emojis-tabs">
-                        <span class="emojis-tab active" data-category="symbols">Símbolos</span>
-                        <span class="emojis-tab" data-category="nature">Natureza</span>
-                        <span class="emojis-tab" data-category="people">Pessoas</span>
-                        <span class="emojis-tab" data-category="pop">Pop</span>
-                        <span class="emojis-tab" data-category="phrases">Frases</span>
-                    </div>
-                    <span class="char" data-category="symbols" data-value="A">A</span>
-                    <span class="char" data-category="symbols" data-value="B">B</span>
-                    <span class="char" data-category="symbols" data-value="C">C</span>
-                    <span class="char" data-category="symbols" data-value="D">D</span>
-                    <span class="char" data-category="symbols" data-value="E">E</span>
-                    <span class="char" data-category="symbols" data-value="F">F</span>
-                    <span class="char" data-category="symbols" data-value="G">G</span>
-                    <span class="char" data-category="nature" data-value="H">H</span>
-                    <span class="char" data-category="nature" data-value="I">I</span>
-                    <span class="char" data-category="nature" data-value="J">J</span>
-                    <span class="char" data-category="nature" data-value="K">K</span>
-                    <span class="char" data-category="nature" data-value="L">L</span>
-                    <span class="char" data-category="people" data-value="M">M</span>
-                    <span class="char" data-category="people" data-value="N">N</span>
-                    <span class="char" data-category="people" data-value="O">O</span>
-                    <span class="char" data-category="people" data-value="P">P</span>
-                    <span class="char" data-category="people" data-value="Q">Q</span>
-                    <span class="char" data-category="people" data-value="R">R</span>
-                    <span class="char" data-category="symbols" data-value="S">S</span>
-                    <span class="char" data-category="symbols" data-value="T">T</span>
-                    <span class="char" data-category="symbols" data-value="U">U</span>
-                    <span class="char" data-category="symbols" data-value="V">V</span>
-                    <span class="char" data-category="symbols" data-value="W">W</span>
-                    <span class="char" data-category="symbols" data-value="X">X</span>
-                    <span class="char" data-category="symbols" data-value="Y">Y</span>
-                    <span class="char" data-category="symbols" data-value="Z">Z</span>
-                    <span class="char" data-category="nature" data-value="a">a</span>
-                    <span class="char" data-category="symbols" data-value="b">b</span>
-                    <span class="char" data-category="people" data-value="c">c</span>
-                    <span class="char" data-category="people" data-value="d">d</span>
-                    <span class="char" data-category="symbols" data-value="e">e</span>
-                    <span class="char" data-category="pop" data-value="f">f</span>
-                    <span class="char" data-category="pop" data-value="g">g</span>
-                    <span class="char" data-category="pop" data-value="h">h</span>
-                    <span class="char" data-category="pop" data-value="i">i</span>
-                    <span class="char" data-category="nature" data-value="j">j</span>
-                    <span class="char" data-category="pop" data-value="k">k</span>
-                    <span class="char" data-category="people" data-value="l">l</span>
-                    <span class="char" data-category="people" data-value="m">m</span>
-                    <span class="char" data-category="people" data-value="n">n</span>
-                    <span class="char" data-category="people" data-value="o">o</span>
-                    <span class="char" data-category="pop" data-value="p">p</span>
-                    <span class="char" data-category="pop" data-value="q">q</span>
-                    <span class="char" data-category="pop" data-value="r">r</span>
-                    <span class="char" data-category="pop" data-value="s">s</span>
-                    <span class="char" data-category="pop" data-value="$">$</span>
-                    <span class="char" data-category="pop" data-value="@">@</span>
-                    <span class="char" data-category="pop" data-value="t">t</span>
-                    <span class="char" data-category="pop" data-value="u">u</span>
-                    <span class="char" data-category="pop" data-value="v">v</span>
-                    <span class="char" data-category="pop" data-value="w">w</span>
-                    <span class="char" data-category="pop" data-value="x">x</span>
-                    <span class="char" data-category="pop" data-value="y">y</span>
-                    <span class="char" data-category="pop" data-value="z">z</span>
-                    <span class="char" data-category="people" data-value=",">,</span>
-                    <span class="char" data-category="people" data-value="0">0</span>
-                    <span class="char" data-category="people" data-value="1">1</span>
-                    <span class="char" data-category="people" data-value="2">2</span>
-                    <span class="char" data-category="people" data-value="3">3</span>
-                    <span class="char" data-category="people" data-value="\">\</span>
-                    <span class="char" data-category="people" data-value=":">:</span>
-                    <span class="char" data-category="people" data-value=";">;</span>
-                    <span class="char" data-category="people" data-value="&lt;">&lt;</span>
-                    <span class="char" data-category="people" data-value="=">=</span>
-                    <span class="char" data-category="people" data-value="&gt;">&gt;</span>
-                    <span class="char" data-category="people" data-value="!">!</span>
-                    <span class="char" data-category="people" data-value="?">?</span>
-                    <span class="char" data-category="people" data-value="'">'</span>
-                    <span class="char" data-category="people" data-value="&quot;">&quot;</span>
-                    <span class="char" data-category="people" data-value="#">#</span>
-                    <span class="char" data-category="symbols" data-value="4">4</span>
-                    <span class="char" data-category="symbols" data-value="5">5</span>
-                    <span class="char" data-category="symbols" data-value="6">6</span>
-                    <span class="char" data-category="symbols" data-value="7">7</span>
-                    <span class="char" data-category="symbols" data-value="8">8</span>
-                    <span class="char" data-category="symbols" data-value="9">9</span>
-                    <span class="char" data-category="symbols" data-value="-">-</span>
-                    <span class="char" data-category="symbols" data-value="+">+</span>
-                    <span class="char" data-category="symbols" data-value="*">*</span>
-                    <span class="char" data-category="symbols" data-value="^">^</span>
-                    <span class="char" data-category="symbols" data-value="˜">˜</span>
-                    <span class="char" data-category="symbols" data-value="/">/</span>
-                    <span class="char" data-category="phrases" data-value="%">%</span>
-                    <span class="char" data-category="phrases" data-value="&amp;">&amp;</span>
-                    <span class="char" data-category="phrases" data-value="(">(</span>
-                    <span class="char" data-category="phrases" data-value=")">)</span>
-                    <span class="char" data-category="phrases" data-value="[">[</span>
-                    <span class="char" data-category="phrases" data-value="{">{</span>
-                    <span class="char" data-category="phrases" data-value="|">|</span>
-                    <span class="char" data-category="phrases" data-value="}">}</span>
+                <div class="emojis-container" data-active="symbols"
+                     data-label-symbols="Símbolos"
+                     data-label-nature="Natureza"
+                     data-label-people="Pessoas"
+                     data-label-pop="Pop"
+                     data-label-phrases="Frases"
+                     data-label-other="Outros">
                     <br />
                     <span class="char utility" data-value="⌫" style="min-width: 66px;"><svg class="keyboard-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M10 5a2 2 0 0 0-1.344.519l-6.328 5.74a1 1 0 0 0 0 1.481l6.328 5.741A2 2 0 0 0 10 19h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2z"/><path d="m12 9 6 6"/><path d="m18 9-6 6"/></svg></span>
                     <span class="char utility" data-value="⎵" style="min-width: 220px;"><svg class="keyboard-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M22 17v1c0 .5-.5 1-1 1H3c-.5 0-1-.5-1-1v-1"/></svg></span>

--- a/views/viewport.ejs
+++ b/views/viewport.ejs
@@ -331,104 +331,13 @@
                     <span class="char utility" data-value="⎵" style="min-width: 340px;"><svg class="keyboard-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M22 17v1c0 .5-.5 1-1 1H3c-.5 0-1-.5-1-1v-1"/></svg></span>
                     <span class="char utility" data-value="↵" style="min-width: 66px;"><svg class="keyboard-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M20 4v7a4 4 0 0 1-4 4H4"/><path d="m9 10-5 5 5 5"/></svg></span>
                 </div>
-                <div class="emojis-container" data-active="symbols">
-                    <div class="emojis-tabs">
-                        <span class="emojis-tab active" data-category="symbols">Symbols</span>
-                        <span class="emojis-tab" data-category="nature">Nature</span>
-                        <span class="emojis-tab" data-category="people">People</span>
-                        <span class="emojis-tab" data-category="pop">Pop</span>
-                        <span class="emojis-tab" data-category="phrases">Phrases</span>
-                    </div>
-                    <span class="char" data-category="symbols" data-value="A">A</span>
-                    <span class="char" data-category="symbols" data-value="B">B</span>
-                    <span class="char" data-category="symbols" data-value="C">C</span>
-                    <span class="char" data-category="symbols" data-value="D">D</span>
-                    <span class="char" data-category="symbols" data-value="E">E</span>
-                    <span class="char" data-category="symbols" data-value="F">F</span>
-                    <span class="char" data-category="symbols" data-value="G">G</span>
-                    <span class="char" data-category="nature" data-value="H">H</span>
-                    <span class="char" data-category="nature" data-value="I">I</span>
-                    <span class="char" data-category="nature" data-value="J">J</span>
-                    <span class="char" data-category="nature" data-value="K">K</span>
-                    <span class="char" data-category="nature" data-value="L">L</span>
-                    <span class="char" data-category="people" data-value="M">M</span>
-                    <span class="char" data-category="people" data-value="N">N</span>
-                    <span class="char" data-category="people" data-value="O">O</span>
-                    <span class="char" data-category="people" data-value="P">P</span>
-                    <span class="char" data-category="people" data-value="Q">Q</span>
-                    <span class="char" data-category="people" data-value="R">R</span>
-                    <span class="char" data-category="symbols" data-value="S">S</span>
-                    <span class="char" data-category="symbols" data-value="T">T</span>
-                    <span class="char" data-category="symbols" data-value="U">U</span>
-                    <span class="char" data-category="symbols" data-value="V">V</span>
-                    <span class="char" data-category="symbols" data-value="W">W</span>
-                    <span class="char" data-category="symbols" data-value="X">X</span>
-                    <span class="char" data-category="symbols" data-value="Y">Y</span>
-                    <span class="char" data-category="symbols" data-value="Z">Z</span>
-                    <span class="char" data-category="nature" data-value="a">a</span>
-                    <span class="char" data-category="symbols" data-value="b">b</span>
-                    <span class="char" data-category="people" data-value="c">c</span>
-                    <span class="char" data-category="people" data-value="d">d</span>
-                    <span class="char" data-category="symbols" data-value="e">e</span>
-                    <span class="char" data-category="pop" data-value="f">f</span>
-                    <span class="char" data-category="pop" data-value="g">g</span>
-                    <span class="char" data-category="pop" data-value="h">h</span>
-                    <span class="char" data-category="pop" data-value="i">i</span>
-                    <span class="char" data-category="nature" data-value="j">j</span>
-                    <span class="char" data-category="pop" data-value="k">k</span>
-                    <span class="char" data-category="people" data-value="l">l</span>
-                    <span class="char" data-category="people" data-value="m">m</span>
-                    <span class="char" data-category="people" data-value="n">n</span>
-                    <span class="char" data-category="people" data-value="o">o</span>
-                    <span class="char" data-category="pop" data-value="p">p</span>
-                    <span class="char" data-category="pop" data-value="q">q</span>
-                    <span class="char" data-category="pop" data-value="r">r</span>
-                    <span class="char" data-category="pop" data-value="s">s</span>
-                    <span class="char" data-category="pop" data-value="$">$</span>
-                    <span class="char" data-category="pop" data-value="@">@</span>
-                    <span class="char" data-category="pop" data-value="t">t</span>
-                    <span class="char" data-category="pop" data-value="u">u</span>
-                    <span class="char" data-category="pop" data-value="v">v</span>
-                    <span class="char" data-category="pop" data-value="w">w</span>
-                    <span class="char" data-category="pop" data-value="x">x</span>
-                    <span class="char" data-category="pop" data-value="y">y</span>
-                    <span class="char" data-category="pop" data-value="z">z</span>
-                    <span class="char" data-category="people" data-value=",">,</span>
-                    <span class="char" data-category="people" data-value="0">0</span>
-                    <span class="char" data-category="people" data-value="1">1</span>
-                    <span class="char" data-category="people" data-value="2">2</span>
-                    <span class="char" data-category="people" data-value="3">3</span>
-                    <span class="char" data-category="people" data-value="\">\</span>
-                    <span class="char" data-category="people" data-value=":">:</span>
-                    <span class="char" data-category="people" data-value=";">;</span>
-                    <span class="char" data-category="people" data-value="&lt;">&lt;</span>
-                    <span class="char" data-category="people" data-value="=">=</span>
-                    <span class="char" data-category="people" data-value="&gt;">&gt;</span>
-                    <span class="char" data-category="people" data-value="!">!</span>
-                    <span class="char" data-category="people" data-value="?">?</span>
-                    <span class="char" data-category="people" data-value="'">'</span>
-                    <span class="char" data-category="people" data-value="&quot;">&quot;</span>
-                    <span class="char" data-category="people" data-value="#">#</span>
-                    <span class="char" data-category="symbols" data-value="4">4</span>
-                    <span class="char" data-category="symbols" data-value="5">5</span>
-                    <span class="char" data-category="symbols" data-value="6">6</span>
-                    <span class="char" data-category="symbols" data-value="7">7</span>
-                    <span class="char" data-category="symbols" data-value="8">8</span>
-                    <span class="char" data-category="symbols" data-value="9">9</span>
-                    <span class="char" data-category="symbols" data-value="-">-</span>
-                    <span class="char" data-category="symbols" data-value="+">+</span>
-                    <span class="char" data-category="symbols" data-value="*">*</span>
-                    <span class="char" data-category="symbols" data-value="^">^</span>
-                    <span class="char" data-category="symbols" data-value="˜">˜</span>
-                    <span class="char" data-category="symbols" data-value="/">/</span>
-                    <span class="char" data-category="phrases" data-value="%">%</span>
-                    <span class="char" data-category="phrases" data-value="&amp;">&amp;</span>
-                    <span class="char" data-category="phrases" data-value="(">(</span>
-                    <span class="char" data-category="phrases" data-value=")">)</span>
-                    <span class="char" data-category="phrases" data-value="[">[</span>
-                    <span class="char" data-category="phrases" data-value="{">{</span>
-                    <span class="char" data-category="phrases" data-value="|">|</span>
-                    <span class="char" data-category="phrases" data-value="}">}</span>
+                <div class="emojis-container" data-active="symbols"
+                     data-label-symbols="Symbols"
+                     data-label-nature="Nature"
+                     data-label-people="People"
+                     data-label-pop="Pop"
+                     data-label-phrases="Phrases"
+                     data-label-other="Other">
                     <br />
                     <span class="char utility" data-value="⌫" style="min-width: 66px;"><svg class="keyboard-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M10 5a2 2 0 0 0-1.344.519l-6.328 5.74a1 1 0 0 0 0 1.481l6.328 5.741A2 2 0 0 0 10 19h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2z"/><path d="m12 9 6 6"/><path d="m18 9-6 6"/></svg></span>
                     <span class="char utility" data-value="⎵" style="min-width: 220px;"><svg class="keyboard-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M22 17v1c0 .5-.5 1-1 1H3c-.5 0-1-.5-1-1v-1"/></svg></span>


### PR DESCRIPTION
## Summary

Makes the emoji keyboard layout (which emoji, in which tab, in what order) a configuration concern owned by the already uploadable mapping file, instead of being hardcoded in the viewport templates. Also adds a way to download the current mapping from the settings Emojis tab.

Closes #61.

## What changed

- **Mapping format** — each `coolemojis.mapping.json` entry may now be either the plain glyph name string (unchanged) or the extended object form `{name, category?, order?}`. The bundled mapping was regenerated to the extended form, preserving the original 5 tabs and key order exactly.
- **Catch-all "Other" tab** — entries without an explicit category are gathered on a dedicated "Other" tab (appended last, only when present), so uncategorized uploads stay visible. The previously unreachable `€` glyph now surfaces there.
- **Client-side generation** — the emoji keyboard tabs and keys are built from the mapping in `main.js` and wired through the existing keyboard plugin; the templates keep only the container shell plus the trailing utility keys. Category labels stay localizable via `data-label-*` (English + pt_pt). Degrades gracefully if the mapping fetch fails.
- **Upload validation** — `validateEmojisMapping` accepts the extended object form, with precise per-field errors.
- **Engrave payload** — `multifontText` resolves the glyph name from either mapping form so the engraving payload stays correct.
- **Download current mapping** — new admin route `GET /settings/emojis/mapping` serves the active mapping as an attachment, surfaced as a "Download current" button in the settings Emojis tab (English + pt_pt).
- **Proposal doc** — `docs/proposals/emoji-keyboard-config.md`.

## Testing

- `npm test` — 151 passing (added validator cases for the extended mapping form and a smoke test for the new download route).
- `npm run lint` — clean.
- `npm run build` — bundles regenerated and in sync.

## Notes

- The Pantograph keyboard (`.emojisp-container`) stays static — there is no `coolemojisp.mapping.json`, so making it mapping-driven would empty it.
- The `data-active` category filter in CSS is still hand-enumerated, extended with `other`; fully arbitrary admin-defined category names beyond the shipped set would need a generic filtering mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hivesolutions/codesmith/signatur/pr/62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784102834&installation_id=139073056&pr_number=62&repository=hivesolutions%2Fsignatur&return_to=https%3A%2F%2Fgithub.com%2Fhivesolutions%2Fsignatur%2Fpull%2F62&signature=ea5a35b35f5cd3a64fbf67299040c2545dcf614732dd506abd730d10ce67a67c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Emoji keyboard layout now configurable via uploadable mapping file with category and order support
  * Uncategorized emojis automatically placed in dedicated "Other" tab
  * Download current emoji mapping from settings panel

* **Tests**
  * Added test coverage for emoji mapping download and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->